### PR TITLE
Fix to a race condition that writing dirty data to immutable file

### DIFF
--- a/tests/jungle/basic_op_test.cc
+++ b/tests/jungle/basic_op_test.cc
@@ -1822,3 +1822,4 @@ int main(int argc, char** argv) {
 
     return 0;
 }
+


### PR DESCRIPTION
* This issue has no impact on data integrity, but will print false
warnings.

* Now log files become immutable only after actual "sync" to file.