### PR TITLE
Support level migration

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -68,8 +68,8 @@ public:
         , logFileTtl_sec(0)
         , maxKeepingMemtables(0)
         , maxKeepingCheckpoints(10)
-        , maxEntriesInLogFile(16384)        // 16K
-        , maxLogFileSize(4194304)           // 4MB
+        , maxEntriesInLogFile(16384)        // 16 KiB
+        , maxLogFileSize(4194304)           // 4 MiB
         , cmpFunc(nullptr)
         , cmpFuncParam(nullptr)
         , compactionCbFunc(nullptr)
@@ -77,7 +77,7 @@ public:
         , throttlingThreshold(10000)
         , bulkLoading(false)
         , numL0Partitions(4)
-        , minFileSizeToCompact(16777216)    // 16MB
+        , minFileSizeToCompact(16777216)    // 16 MiB
         , minBlockReuseCycleToCompact(0)
         , maxBlockReuseCycle(1)
         , compactionFactor(300)             // 300%
@@ -86,9 +86,9 @@ public:
         , useBloomFilterForGet(true)
         , bloomFilterBitsPerUnit(0.0)
         , nextLevelExtension(true)
-        , maxL0TableSize(1073741824)            // 1GB
-        , maxL1TableSize(2684354560)            // 2.5GB
-        , maxL1Size((uint64_t)120 * 1073741824) // 120 GB
+        , maxL0TableSize(1073741824)                // 1 GiB
+        , maxL1TableSize(2684354560)                // 2.5 GiB
+        , maxL1Size((uint64_t)1024 * 1073741824)    // 1 TiB
         , maxParallelWritesPerJob(0)
         , readOnly(false)
         , preFlushDirtyInterval_sec(5)

--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -106,6 +106,7 @@ struct DebugParams {
         , tableSetBatchCb(nullptr)
         , addNewLogFileCb(nullptr)
         , newLogBatchCb(nullptr)
+        , forceMerge(false)
         {}
 
     /**
@@ -179,6 +180,12 @@ struct DebugParams {
      * visible.
      */
     std::function< void(const GenericCbParams&) > newLogBatchCb;
+
+    /**
+     * If true, merge will proceed the task even with the small number
+     * of tables in the level.
+     */
+    bool forceMerge;
 };
 
 using UserHandler = std::function< void(Status, void*) >;

--- a/src/table_compact_condition.cc
+++ b/src/table_compact_condition.cc
@@ -54,6 +54,17 @@ Status TableMgr::pickVictimTable(size_t level,
 
     // No table to compact, return.
     if (!tables.size()) return Status::TABLE_NOT_FOUND;
+    if ( policy == SMALL_WORKING_SET &&
+         tables.size() <= db_config->numL0Partitions * 2 ) {
+        // Too small number of tables in the level,
+        // don't need to merge.
+        if ( d_params_effective && d_params.forceMerge ) {
+            // Debug mode is on, proceed it.
+        } else {
+            for (TableInfo*& entry: tables) entry->done();
+            return Status::TABLE_NOT_FOUND;
+        }
+    }
 
     std::vector<VictimCandidate> candidates;
 

--- a/src/table_manifest.cc
+++ b/src/table_manifest.cc
@@ -456,7 +456,7 @@ Status TableManifest::removeTableFile(size_t level,
                        t_info->minKey.toReadableString().c_str(),
                        t_info->refCount.load(),
                        cur_level->numTables.load() );
-
+            return Status();
         }
         cursor = skiplist_next(cur_level->tables, cursor);
         skiplist_release_node(&t_info->snode);

--- a/src/table_manifest.h
+++ b/src/table_manifest.h
@@ -93,12 +93,14 @@ struct TableInfo {
                       "ref count %zu -> %zu status %d mflag %s",
                       level, number, count, count-1, status.load(),
                       (migration ? "ON" : "OFF") );
-            // NOTE: We should not remove file object if this
-            //       table is being migrated to next level, as
-            //       next level's table info will reuse it.
-            if (count == 1 && !migration) {
-                file->destroySelf();
-                delete file;
+            if (count == 1) {
+                // NOTE: We should not remove file object if this
+                //       table is being migrated to next level, as
+                //       next level's table info will reuse it.
+                if (!migration) {
+                    file->destroySelf();
+                    delete file;
+                }
                 delete this;
             }
             return;

--- a/src/table_mgr.h
+++ b/src/table_mgr.h
@@ -189,6 +189,9 @@ public:
                            TableInfo* victim_table,
                            size_t level);
 
+    Status migrateLevel(const CompactOptions& options,
+                        size_t level);
+
     Status compactInPlace(const CompactOptions& options,
                           TableInfo* victim_table,
                           size_t level,


### PR DESCRIPTION
* Once level extension happens (i.e., the interlevel compaction to a
new level), we can just move all tables in the previous level to the
new level without re-writing tables.

* Intermediate level tables doesn't need to be removed after interlevel
compaction, as it will cause surplus split in the future. We can keep
the range if there are not many tables in the level.