### PR TITLE
[Bench] Support cloning workers

### DIFF
--- a/tests/bench/bench.cc
+++ b/tests/bench/bench.cc
@@ -526,7 +526,8 @@ int bench_worker(TestSuite::ThreadArgs* base_args) {
     const WorkerDef& my_def = args->conf.workerDefs[args->wId];
 
 #ifdef __linux__
-    std::string t_name = "bench_w_" + std::to_string(args->wId);
+    std::string t_name = my_def.getThreadName() + "_" +
+                         std::to_string(args->wId);
     pthread_setname_np(pthread_self(), t_name.c_str());
 #endif
 
@@ -681,12 +682,12 @@ int displayer(TestSuite::ThreadArgs* base_args) {
                 dd.set( 4, 2, "--" );
             }
             // Instant write throughput.
-            dd.set( 4, 3, "%s/s",
+            dd.set( 4, 3, "I %s/s",
                     TestSuite::sizeThroughputStr
                                ( w_amt - args->stat.amountWriteByte,
                                  inst_time_us ).c_str() );
             // Average write throughput.
-            dd.set( 4, 4, "%s/s",
+            dd.set( 4, 4, "A %s/s",
                     TestSuite::sizeThroughputStr
                                ( w_amt, tt.getTimeUs() ).c_str() );
             args->stat.amountWriteByte = w_amt;
@@ -698,9 +699,9 @@ int displayer(TestSuite::ThreadArgs* base_args) {
             cpu_inst_base = cur_cpu_ms;
             args->stat.cpuMs = cpu_ms;
             // Instant usage (since last display).
-            dd.set( 6, 1, "%.1f %%", (double)cpu_ms_inst / inst_time_ms * 100 );
+            dd.set( 6, 1, "I %.1f %%", (double)cpu_ms_inst / inst_time_ms * 100 );
             // Overall average.
-            dd.set( 6, 2, "%.1f %%", (double)cpu_ms / tt.getTimeMs() * 100 );
+            dd.set( 6, 2, "A %.1f %%", (double)cpu_ms / tt.getTimeMs() * 100 );
 
             // RSS.
             uint64_t rss_amount = get_mem_usage();

--- a/tests/bench/bench_config.h
+++ b/tests/bench/bench_config.h
@@ -88,7 +88,12 @@ struct BenchConfig {
             for (size_t ii = 0; ii < num; ++ii) {
                 WorkerDef ww = WorkerDef::load(w_obj[ii]);
                 if (ww.type != WorkerDef::UNKNOWN) {
-                    conf.workerDefs.push_back(ww);
+                    size_t num_clones = 1;
+                    _jint(num_clones, w_obj[ii], "num_clones");
+
+                    for (size_t jj = 0; jj < num_clones; ++jj) {
+                        conf.workerDefs.push_back(ww);
+                    }
                 }
             }
         }

--- a/tests/bench/bench_worker.h
+++ b/tests/bench/bench_worker.h
@@ -67,7 +67,7 @@ struct WorkerDef {
         return WorkerDef(type, rate, batch);
     }
 
-    std::string toString() {
+    std::string toString() const {
         char msg[128];
         static std::unordered_map<int, std::string>
             w_type_name
@@ -89,6 +89,25 @@ struct WorkerDef {
             ss << ", batch " << batchSize.toString();
         }
         return ss.str();
+    }
+
+    std::string getThreadName() const {
+        std::string ret = "bench_";
+        switch (type) {
+        case WRITER:
+            ret += "w";
+            break;
+        case POINT_READER:
+            ret += "p";
+            break;
+        case RANGE_READER:
+            ret += "r";
+            break;
+        default:
+            ret += "u";
+            break;
+        }
+        return ret;
     }
 
     Type type;

--- a/tests/bench/dist_def.h
+++ b/tests/bench/dist_def.h
@@ -180,7 +180,7 @@ struct DistDef {
      *
      * @return Information string.
      */
-    std::string toString() {
+    std::string toString() const {
         std::stringstream ss;
 
         if (type == RANDOM || type == NORMAL) {

--- a/tests/bench/example_config.json
+++ b/tests/bench/example_config.json
@@ -22,11 +22,13 @@
   "workers": [
     {
       "type": "writer",
-      "rate": 2000
+      "rate": 1000,
+      "num_clones": 2
     },
     {
       "type": "point_reader",
-      "rate": 2000
+      "rate": 2000,
+      "num_clones": 2
     },
     {
       "type": "range_reader",
@@ -42,12 +44,10 @@
     "cache_size_mb": 1024,
     "wal_size_mb": 64,
     "compaction_factor": 240,
-    "max_tiering_limit": 10,
-    "merge_mode": "appending",
     "block_reuse_factor": 0,
     "l0_table_size_mb": 1024,
     "l1_table_size_mb": 2560,
-    "l1_size_mb": 122880,
+    "l1_size_mb": 1048576,
     "bloom_filter_bits": 10.0,
     "num_table_writers": 8,
     "num_compactor_threads": 2


### PR DESCRIPTION
* Instead of specifying the same workers multiple times, we can just
put `num_clones` field to generate multiple workers doing the same job.

* Added `I` and `A` prefix to disk/CPU usage, for indicating instant
and average number.