### PR TITLE
Fix to potential log manifest corruption

### DIFF
--- a/src/internal_helper.cc
+++ b/src/internal_helper.cc
@@ -316,7 +316,8 @@ Status BackupRestore::backup(FileOps* f_ops,
 Status BackupRestore::backup(FileOps* f_ops,
                              const std::string& filename,
                              const SizedBuf& ctx,
-                             size_t length)
+                             size_t length,
+                             bool call_fsync)
 {
     Status s;
     std::string dst_file = filename + ".bak";
@@ -327,6 +328,9 @@ Status BackupRestore::backup(FileOps* f_ops,
     TC( f_ops->open(&d_file, dst_file) );
     TC( f_ops->pwrite(d_file, ctx.data, length, 0) );
     f_ops->ftruncate(d_file, length);
+    if (call_fsync) {
+        f_ops->fsync(d_file);
+    }
     f_ops->close(d_file);
     delete d_file;
     return s;

--- a/src/internal_helper.h
+++ b/src/internal_helper.h
@@ -126,7 +126,8 @@ public:
     static Status backup(FileOps* f_ops,
                          const std::string& filename,
                          const SizedBuf& ctx,
-                         size_t length);
+                         size_t length,
+                         bool call_fsync);
     static Status restore(FileOps* f_ops,
                           const std::string& filename);
 };

--- a/src/log_manifest.h
+++ b/src/log_manifest.h
@@ -204,7 +204,7 @@ public:
     Status load(const std::string& path,
                 const std::string& filename,
                 const uint64_t prefix_num);
-    Status store();
+    Status store(bool call_fsync);
     static Status copyFile(FileOps* f_ops,
                            const std::string& src_file,
                            const std::string& dst_file);
@@ -212,7 +212,6 @@ public:
                          const std::string& filename);
     static Status restore(FileOps* f_ops,
                           const std::string& filename);
-    Status sync();
 
     Status issueLogFileNumber(uint64_t& new_log_file_number);
 


### PR DESCRIPTION
* Log manifest backup file should created after `fsync` of the
original manifest file is done. Otherwise, there is a small
possibility of the corruption of both files at the same time.

* Refactored internal APIs, no need to maintain a separate `sync`
API for manifest.