### PR TITLE
Support compaction throttling

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -483,6 +483,48 @@ public:
     IdleTimeCompactionOptions itcOpt;
 
     /**
+     * Settings for compaction (inclugin split/merge) throttling.
+     *
+     * Throttling is disabled by default, so that compactor thread
+     * will do compaction at its best if below values are unchanged.
+     */
+    struct CompactionThrottlingOptions {
+        CompactionThrottlingOptions()
+            : resolution_ms(200)
+            , throttlingFactor(0)
+            {}
+
+        /**
+         * Time interval to execute throttling.
+         */
+        uint32_t resolution_ms;
+
+        /**
+         * A number deciding how much it will throttle the compaction,
+         * ranged between 0 to 99.
+         * If
+         *   1) zero, throttling is completely disabled.
+         *   2) F, compactor thread's utilization will be at most (100-X) %.
+         *     e.g.)
+         *       F = 10, compactor will run at 90% of its max speed.
+         *       F = 50, compactor will run at 50% of its max speed.
+         *       F = 80, compactor will run at 20% of its max speed.
+         */
+        uint32_t throttlingFactor;
+    };
+
+    /**
+     * Compaction throttling options.
+     *
+     * It can be used to reduce the influence on user-facing latency
+     * by heavy IO of compaction tasks.
+     *
+     * Interlevel/in-place compactions, split, and merge will get affected.
+     * Log flushing (to L0 tables) will have no effect.
+     */
+    CompactionThrottlingOptions ctOpt;
+
+    /**
      * Shutdown system logger on shutdown of Jungle.
      */
     bool shutdownLogger;

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -61,9 +61,14 @@ void DBMgr::printGlobalConfig() {
                       gConfig.itcOpt.startHour, gConfig.itcOpt.endHour,
                       (tz_gap >= 0)?'+':'-', tz_gap_abs / 60, tz_gap_abs % 60);
         }
+
     } else {
         _log_info(myLog, "idle time compaction disabled");
     }
+
+    _log_info(myLog, "compaction throttling resolution %zu ms factor %zu",
+              gConfig.ctOpt.resolution_ms,
+              gConfig.ctOpt.throttlingFactor);
 }
 
 void DBMgr::initInternal(const GlobalConfig& config) {

--- a/tests/bench/db_adapter_jungle.cc
+++ b/tests/bench/db_adapter_jungle.cc
@@ -70,6 +70,8 @@ int JungleAdapter::open(const std::string& db_file,
     g_config.itcOpt.startHour = 0;
     g_config.itcOpt.endHour = 0;
 
+    g_config.ctOpt.throttlingFactor = 0;
+
     jungle::init(g_config);
 
     jungle::DBConfig config;


### PR DESCRIPTION
* There are use cases that want to minimize the impact of compaction
overhead on user-facing latencies. To do that, we need a throttling
mechanism for compaction jobs.