### PR TITLE
Fix to bug regarding out of range in seq iterator

### DIFF
--- a/src/table_file_iterator.cc
+++ b/src/table_file_iterator.cc
@@ -138,7 +138,13 @@ Status TableFile::Iterator::initSN(DB* snap_handle,
         minSeq = 0;
     }
     if (valid_number(max_seq)) {
-        maxSeq = std::min(snap_seqnum, max_seq);
+        // If `snap_seqnum` is zero and `max_seq` is given,
+        // we should honor `max_seq`.
+        if (snap_seqnum) {
+            maxSeq = std::min(snap_seqnum, max_seq);
+        } else {
+            maxSeq = max_seq;
+        }
     } else {
         maxSeq = 0;
     }


### PR DESCRIPTION
* If max seq number is manually given, it should be honored unless
the iterator is based on snapshot.