### PR TITLE
Update manifest backup file only after successful fsync

### DIFF
--- a/src/table_manifest.cc
+++ b/src/table_manifest.cc
@@ -316,14 +316,17 @@ Status TableManifest::store(bool call_fsync) {
     fOps->ftruncate(mFile, ss.pos());
 
     if (call_fsync) {
-        fOps->fsync(mFile);
+        s = fOps->fsync(mFile);
+        if (s) {
+            // Same as that in log manifest.
+
+            // After success, make a backup file one more time,
+            // using the latest data.
+            EP( BackupRestore::backup(fOps, mFileName, call_fsync) );
+        }
     }
 
-    // After success, make a backup file one more time,
-    // using the latest data.
-    EP( BackupRestore::backup(fOps, mFileName, call_fsync) );
-
-    return Status();
+    return s;
 }
 
 Status TableManifest::storeTableStack(RwSerializer& ss,


### PR DESCRIPTION
* We should update the backup file only when the original manifest file
is synced. If not, both files are dirty simultaneously so that there
can be a possibility that both are corrupted at the same time.