### PR TITLE
Do 2nd pre-scan on split if there is only one output table

### DIFF
--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -103,6 +103,7 @@ struct DebugParams {
         , urgentCompactionRatio(0)
         , rollbackDelayUs(0)
         , logDetailsOfKeyNotFound(false)
+        , disruptSplit(false)
         , tableSetBatchCb(nullptr)
         , addNewLogFileCb(nullptr)
         , newLogBatchCb(nullptr)
@@ -157,6 +158,11 @@ struct DebugParams {
      * If `true`, leave detailed logs if given key is not found.
      */
     bool logDetailsOfKeyNotFound;
+
+    /**
+     * If `true`, split pre-scanning will result only one output table.
+     */
+    bool disruptSplit;
 
     struct GenericCbParams {
         GenericCbParams() {}


### PR DESCRIPTION
* If there is a big error between real working set size and the
estimated one, pre-scan may return just a single result table during
split, which may result in a never-ending task.

* If pre-scan returns invalid output, we should adjust the threshold
based on the actual working set size. The number of output tables
should be at least equal to or greater than 2.