### PR TITLE
Move to next log file even without `sync`

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -69,7 +69,7 @@ public:
         , logFileTtl_sec(0)
         , maxKeepingMemtables(0)
         , maxKeepingCheckpoints(10)
-        , maxEntriesInLogFile(16384)        // 16 KiB
+        , maxEntriesInLogFile(16384)        // 16K
         , maxLogFileSize(4194304)           // 4 MiB
         , cmpFunc(nullptr)
         , cmpFuncParam(nullptr)

--- a/src/log_file.cc
+++ b/src/log_file.cc
@@ -533,7 +533,7 @@ Status LogFile::purgeMemTable() {
     return Status();
 }
 
-uint64_t LogFile::size() const {
+uint64_t LogFile::getMemTableSize() const {
     return mTable ? mTable->size() : 0;
 }
 
@@ -726,6 +726,7 @@ bool LogFile::isValidToWrite() {
     uint32_t max_log_entries = logMgr->getDbConfig()->maxEntriesInLogFile;
     if ( immutable ||
          fileSize > max_log_file_size ||
+         getMemTableSize() > max_log_file_size ||
          mTable->getNumLogs() >= max_log_entries )
         return false;
     return true;

--- a/src/log_file.h
+++ b/src/log_file.h
@@ -87,7 +87,7 @@ public:
 
     bool isMemTablePurged() const { return memtablePurged; }
 
-    uint64_t size() const;
+    uint64_t getMemTableSize() const;
 
     Status sync();
 

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -48,7 +48,7 @@ void LogManifest::reclaimExpiredLogFiles() {
 
         // Collect memory usage info
         if ( !info->file->isMemTablePurged() ) {
-            uint64_t size = info->file->size();
+            uint64_t size = info->file->getMemTableSize();
             if ( size > 0 ) {
                 size_message << ", logfile_" << info->logFileNum << ": " << size;
                 total_memtable_size += size;


### PR DESCRIPTION
* Without `sync`, the log file size doesn't grow, and that blocks
moving to the next file, which may cause various issues like
out-of-memory.

* To address it, we should check the memory consumption as well as
the file size.