### PR TITLE
Avoid OOM when loading log files rapidly.

### DIFF
--- a/src/log_file.cc
+++ b/src/log_file.cc
@@ -253,7 +253,7 @@ Status LogFile::loadMemTable() {
     _log_info(myLog, "loaded memtable of file %zu", logFileNum);
 
     logMgr->increaseOpenMemtable();
-    logMgr->doLogReclaimIfNecessary();
+    logMgr->doBackgroundLogReclaimIfNecessary();
 
     return Status();
 }

--- a/src/log_file.h
+++ b/src/log_file.h
@@ -35,7 +35,7 @@ class LogMgr;
 class LogFile {
     friend class MemTable;
 public:
-    LogFile(const LogMgr* log_mgr);
+    LogFile(LogMgr* log_mgr);
     ~LogFile();
 
     static std::string getLogFileName(const std::string& path,
@@ -221,7 +221,7 @@ private:
     PurgedMemTableMeta memTableOnFileMeta;
 
     // Parent log manager.
-    const LogMgr* logMgr;
+    LogMgr* logMgr;
 
     // Current file size.
     uint64_t fileSize;

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -559,7 +559,7 @@ Status LogManifest::getLogFileInfo(const uint64_t log_num,
     if (force_not_load_memtable) {
         info_out->grab();
     } else {
-        info_out->grab(true);
+        info_out->grab(isLogReclaimerActive());
     }
     skiplist_release_node(cursor);
     return Status();
@@ -582,7 +582,7 @@ Status LogManifest::getLogFileInfoRange(const uint64_t s_log_inc,
         if (force_not_load_memtable) {
             l_info->grab();
         } else {
-            l_info->grab(true);
+            l_info->grab(isLogReclaimerActive());
         }
         info_out.push_back(l_info);
 
@@ -626,7 +626,7 @@ Status LogManifest::getLogFileInfoBySeq(const uint64_t seq_num,
     if (force_not_load_memtable) {
         info_out->grab();
     } else {
-        info_out->grab(true);
+        info_out->grab(isLogReclaimerActive());
     }
     skiplist_release_node(cursor);
     return Status();

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -145,7 +145,7 @@ void LogManifest::reclaimExpiredLogFiles() {
     }
 }
 
-LogManifest::LogManifest(const LogMgr* log_mgr, FileOps* _f_ops, FileOps* _f_l_ops)
+LogManifest::LogManifest(LogMgr* log_mgr, FileOps* _f_ops, FileOps* _f_l_ops)
     : fOps(_f_ops)
     , fLogOps(_f_l_ops)
     , mFile(nullptr)
@@ -559,7 +559,7 @@ Status LogManifest::getLogFileInfo(const uint64_t log_num,
     if (force_not_load_memtable) {
         info_out->grab();
     } else {
-        info_out->grab(isLogReclaimerActive());
+        info_out->grab(true);
     }
     skiplist_release_node(cursor);
     return Status();
@@ -582,7 +582,7 @@ Status LogManifest::getLogFileInfoRange(const uint64_t s_log_inc,
         if (force_not_load_memtable) {
             l_info->grab();
         } else {
-            l_info->grab(isLogReclaimerActive());
+            l_info->grab(true);
         }
         info_out.push_back(l_info);
 
@@ -626,7 +626,7 @@ Status LogManifest::getLogFileInfoBySeq(const uint64_t seq_num,
     if (force_not_load_memtable) {
         info_out->grab();
     } else {
-        info_out->grab(isLogReclaimerActive());
+        info_out->grab(true);
     }
     skiplist_release_node(cursor);
     return Status();

--- a/src/log_manifest.h
+++ b/src/log_manifest.h
@@ -76,7 +76,7 @@ struct LogFileInfo {
     void grab(bool load_memtable_if_needed = false) {
         refCount.fetch_add(1);
 
-        std::lock_guard<std::recursive_mutex> l(evictionLock);
+        std::lock_guard<std::mutex> l(evictionLock);
         if (load_memtable_if_needed) {
             if (file->isMemTablePurged()) {
                 file->loadMemTable();
@@ -128,7 +128,7 @@ struct LogFileInfo {
         if (evicted) {
             uint64_t count = refCount.fetch_sub(1);
             if (count == 1) {
-                std::lock_guard<std::recursive_mutex> l(evictionLock);
+                std::lock_guard<std::mutex> l(evictionLock);
                 // WARNING:
                 //   There shouldn't be another thread that called grab() before this.
                 uint64_t count_protected = refCount.load();
@@ -146,7 +146,7 @@ struct LogFileInfo {
     void setRemoved() { removed.store(true); }
     bool isRemoved() { return removed.load(); }
     void setEvicted() {
-        std::lock_guard<std::recursive_mutex> l(evictionLock);
+        std::lock_guard<std::mutex> l(evictionLock);
         evicted.store(true);
     }
     bool isEvicted() { return evicted.load(); }
@@ -170,7 +170,7 @@ struct LogFileInfo {
     std::atomic<bool> evicted;
 
     // Lock for loading & evicting mem-table.
-    std::recursive_mutex evictionLock;
+    std::mutex evictionLock;
 };
 
 struct LogFileInfoGuard {

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -1134,9 +1134,13 @@ Status LogMgr::doLogReclaim() {
     return Status();
 }
 
-Status LogMgr::doLogReclaimIfNecessary() {
+Status LogMgr::doBackgroundLogReclaimIfNecessary() {
     if (numMemtables > getDbConfig()->maxKeepingMemtables) {
-        return doLogReclaim();
+        DBMgr* db_mgr = DBMgr::getWithoutInit();
+        if (!db_mgr) {
+            return Status::NOT_INITIALIZED;
+        }
+        return db_mgr->workerMgr()->invokeWorker("reclaimer");
     }
     return Status();
 }

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -40,6 +40,7 @@ LogMgr::LogMgr(DB* parent_db, const LogMgrOptions& _options)
     , lastFlushIntervalMs(0)
     , numSetRecords(0)
     , visibleSeqBarrier(0)
+    , numMemtables(0)
     , myLog(nullptr)
     , vlSync(VERBOSE_LOG_SUPPRESS_MS)
     {}
@@ -1130,6 +1131,13 @@ Status LogMgr::doLogReclaim() {
     assert(ow.op_sema->enabled);
 
     mani->reclaimExpiredLogFiles();
+    return Status();
+}
+
+Status LogMgr::doLogReclaimIfNecessary() {
+    if (numMemtables > getDbConfig()->maxKeepingMemtables) {
+        return doLogReclaim();
+    }
     return Status();
 }
 

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -148,6 +148,9 @@ public:
                  TableMgr* table_mgr);
 
     Status doLogReclaim();
+    Status doLogReclaimIfNecessary();
+    uint32_t increaseOpenMemtable() { return numMemtables.fetch_add(1) + 1; }
+    uint32_t decreaseOpenMemtable() { return numMemtables.fetch_sub(1) - 1; }
 
     Status checkpoint(uint64_t& seq_num_out, bool call_fsync = true);
     Status getAvailCheckpoints(std::list<uint64_t>& chk_out);
@@ -334,6 +337,9 @@ protected:
     // If non-zero, records up to this number (inclusive) will be
     // visible to user.
     std::atomic<uint64_t> visibleSeqBarrier;
+
+    // Number of memory loaded log files.
+    std::atomic<uint32_t> numMemtables;
 
     // Logger.
     SimpleLogger* myLog;

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -148,7 +148,7 @@ public:
                  TableMgr* table_mgr);
 
     Status doLogReclaim();
-    Status doLogReclaimIfNecessary();
+    Status doBackgroundLogReclaimIfNecessary();
     uint32_t increaseOpenMemtable() { return numMemtables.fetch_add(1) + 1; }
     uint32_t decreaseOpenMemtable() { return numMemtables.fetch_sub(1) - 1; }
 


### PR DESCRIPTION
Currently Jungle relies on periodic log reclaimer to evict Memtables.  If we load log files rapidly (e.g. by scanning logs) we may exceed the configured maxKeepingMemtables.

This PR tracks open Memtable count and force log reclaim if open count exceeds configured maxKeepingMemtables.