### PR TITLE
Fix to incorrect init of `evicted` flag

### DIFF
--- a/src/log_file.cc
+++ b/src/log_file.cc
@@ -200,7 +200,7 @@ Status LogFile::load(const std::string& _filename,
     memTableOnFileMeta.flushedSeq = flushed_seq;
     memTableOnFileMeta.syncedSeq = synced_seq;
     memTableOnFileMeta.maxSeq = synced_seq;
-    if (logMgr->isTtlMode()) {
+    if (logMgr->isLogStoreMode()) {
         // If reclaim mode, load mem-table lazily.
         memtablePurged = true;
         return Status();

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -185,7 +185,7 @@ LogManifest::~LogManifest() {
 }
 
 bool LogManifest::isLogReclaimerActive() {
-    return logMgr->isTtlMode();
+    return logMgr->isLogStoreMode();
 }
 
 void LogManifest::spawnReclaimer() {
@@ -650,6 +650,7 @@ Status LogManifest::addNewLogFile(uint64_t log_num,
     LogFileInfo* info = new LogFileInfo(log_num);
     if (!info) return Status::ALLOCATION_FAILURE;
 
+    if (log_file->isMemTablePurged()) info->evicted = true;
     info->file = log_file;
     info->startSeq = start_seqnum;
     skiplist_insert(&logFilesBySeq, &info->snodeBySeq);

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -304,7 +304,7 @@ Status LogMgr::removeStaleFiles() {
     return Status();
 }
 
-bool LogMgr::isTtlMode() const {
+bool LogMgr::isLogStoreMode() const {
     if ( getDbConfig()->logSectionOnly &&
          getDbConfig()->logFileTtl_sec ) {
         return true;

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -102,7 +102,7 @@ public:
 
     Status removeStaleFiles();
 
-    bool isTtlMode() const;
+    bool isLogStoreMode() const;
 
     Status openSnapshot(DB* snap_handle,
                         const uint64_t checkpoint,

--- a/tests/jungle/log_reclaim_test.cc
+++ b/tests/jungle/log_reclaim_test.cc
@@ -1000,6 +1000,22 @@ int immediate_log_purging_test() {
     TestSuite::_msg("open memtables: %zu\n", stats.numOpenMemtables);
     CHK_SM(stats.numOpenMemtables, 2 * config.maxKeepingMemtables);
 
+    // Close and reopen.
+    CHK_Z( jungle::DB::close(db) );
+    CHK_Z( jungle::DB::open(&db, filename, config) );
+
+    // Do the same thing.
+    for (size_t ii=1001; ii<NUM; ++ii) {
+        jungle::KV kv_out;
+        jungle::KV::Holder h(kv_out);
+        CHK_Z( db->getSN(ii+1, kv_out) );
+        TestSuite::sleep_ms(1);
+    }
+
+    db->getStats(stats);
+    TestSuite::_msg("open memtables: %zu\n", stats.numOpenMemtables);
+    CHK_SM(stats.numOpenMemtables, 2 * config.maxKeepingMemtables);
+
     CHK_Z( jungle::DB::close(db) );
     CHK_Z( jungle::shutdown() );
     TEST_SUITE_CLEANUP_PATH();


### PR DESCRIPTION
* If `memtablePurged` is initialized to `true`, `evicted` flag also
should be set to `true`.