### PR TITLE
[Bench] Support compression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,9 @@ endif()
 
 # Find snappy
 include(cmake/FindSnappy.cmake)
-if (SNAPPY_OPTION STREQUAL "Enable")
+if ( (SNAPPY_OPTION STREQUAL "Enable") OR 
+     (SNAPPY_OPTION STREQUAL "enable") )
+    message(STATUS "Snappy option is enabled.")
     if (SNAPPY_FOUND)
         set(LIBSNAPPY ${SNAPPY_LIBRARIES})
         add_definitions(-DSNAPPY_AVAILABLE=1)

--- a/tests/bench/example_config.json
+++ b/tests/bench/example_config.json
@@ -50,6 +50,7 @@
     "l1_size_mb": 1048576,
     "bloom_filter_bits": 10.0,
     "num_table_writers": 8,
-    "num_compactor_threads": 2
+    "num_compactor_threads": 2,
+    "compression": false
   }
 }


### PR DESCRIPTION
* Jungle adapter can enable snappy compression if the library exists.