### PR TITLE
Fix to ref count leak during urgent compaction

### DIFF
--- a/src/compactor.cc
+++ b/src/compactor.cc
@@ -188,6 +188,14 @@ void Compactor::work(WorkerOptions* opt_base) {
                  dbwrap->db->p->tableMgr->getNumWrittenRecords() >
                      num_writes_to_compact ) {
                 target_db = dbwrap->db;
+                if (target_table) {
+                    // WARNING: If there is a table already chosen,
+                    //          we should release it here.
+                    _log_info(dbwrap->db->p->myLog,
+                              "urgent compaction, discard table %zu and "
+                              "find a new victim", target_table->number);
+                    target_table->done();
+                }
                 target_table = nullptr;
                 target_level = start_level;
                 target_strategy = TableMgr::INPLACE_OLD;

--- a/src/table_compact_condition.cc
+++ b/src/table_compact_condition.cc
@@ -30,6 +30,9 @@ struct VictimCandidate {
     uint64_t total;
 };
 
+// WARNING:
+//   `victim_table_out` returned by this function
+//   should be released (i.e., done()) by the caller.
 Status TableMgr::pickVictimTable(size_t level,
                                  VictimPolicy policy,
                                  bool honor_limit,


### PR DESCRIPTION
* If we are going to change the victim table, we should release
the table previously chosen.