### PR TITLE
Skip writing common part of log manifest file

### DIFF
--- a/src/internal_helper.cc
+++ b/src/internal_helper.cc
@@ -323,6 +323,7 @@ Status BackupRestore::backup(FileOps* f_ops,
                              const std::string& filename,
                              const SizedBuf& ctx,
                              size_t length,
+                             size_t bytes_to_skip,
                              bool call_fsync)
 {
     Status s;
@@ -332,7 +333,12 @@ Status BackupRestore::backup(FileOps* f_ops,
 
    try {
     TC( f_ops->open(&d_file, dst_file) );
-    TC( f_ops->pwrite(d_file, ctx.data, length, 0) );
+    if (length > bytes_to_skip) {
+        TC( f_ops->pwrite( d_file,
+                           ctx.data + bytes_to_skip,
+                           length - bytes_to_skip,
+                           bytes_to_skip ) );
+    }
     f_ops->ftruncate(d_file, length);
     if (call_fsync) {
         f_ops->fsync(d_file);

--- a/src/internal_helper.h
+++ b/src/internal_helper.h
@@ -129,6 +129,7 @@ public:
                          const std::string& filename,
                          const SizedBuf& ctx,
                          size_t length,
+                         size_t bytes_to_skip,
                          bool call_fsync);
     static Status restore(FileOps* f_ops,
                           const std::string& filename);

--- a/src/log_manifest.h
+++ b/src/log_manifest.h
@@ -293,12 +293,33 @@ private:
     std::atomic<uint64_t> lastSyncedLog;
     std::atomic<uint64_t> maxLogFileNum;
 
-    // Log files by its file number.
+    /**
+     * Log files by its file number.
+     */
     skiplist_raw logFiles;
 
-    // Log files by its starting (minimum) seq number.
-    // Entries are shared with `logFiles`.
+    /**
+     * Log files by its starting (minimum) seq number.
+     * Entries are shared with `logFiles`.
+     */
     skiplist_raw logFilesBySeq;
+
+    /**
+     * Buffer for caching the last written manifest file data.
+     */
+    SizedBuf cachedManifest;
+
+    /**
+     * Actual length of data in `cachedManifest`, as `cachedManifest`
+     * reserves more memory.
+     */
+    size_t lenCachedManifest;
+
+    /**
+     * If `true`, there is a mismatch between `cachedManifest`
+     * and backup file, so that we cannot do partial write.
+     */
+    bool fullBackupRequired;
 
     LogMgr* logMgr;
     SimpleLogger* myLog;


### PR DESCRIPTION
* If user calls `sync()` API frequently, write amplification will be
very high due to writing log manifest and its backup files.

* To reduce the overall disk IO, we can skip the common part of the
manifest file; we actually write a few bytes at the end of the
manifest.