### PR TITLE
Move parameter of compact by index to TableMgr

### DIFF
--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -428,6 +428,18 @@ public:
                           size_t level);
 
     /**
+     * Do in-place compaction on tables whose index number is
+     * equal to or smaller than the given parameter.
+     * If zero, no more compaction will be triggered.
+     *
+     * @param options Compaction options.
+     * @param idx_upto Upper bound of table index number to compact.
+     * @return OK on success.
+     */
+    Status compactIdxUpto(const CompactOptions& options,
+                          size_t idx_upto);
+
+    /**
      * Do split on a table in the given level, except for level-0.
      * This API will internally find the most suitable table to compact.
      *

--- a/include/libjungle/params.h
+++ b/include/libjungle/params.h
@@ -93,7 +93,6 @@ struct DebugParams {
         , urgentCompactionFilesize(0)
         , urgentCompactionRatio(0)
         , urgentCompactionNumWrites(0)
-        , urgentCompactionMaxTableIdx(0)
         , rollbackDelayUs(0)
         , logDetailsOfKeyNotFound(false)
         , disruptSplit(false)
@@ -140,13 +139,6 @@ struct DebugParams {
      * will take effect.
      */
     uint64_t urgentCompactionNumWrites;
-
-    /**
-     * If non-zero, compaction will be triggered sequentially,
-     * for tables whose index number is equal to or smaller than
-     * this number.
-     */
-    uint64_t urgentCompactionMaxTableIdx;
 
     /**
      * If non-zero, every file removal or truncation during rollback

--- a/prepare.sh
+++ b/prepare.sh
@@ -6,9 +6,12 @@ set -ex
 RECOMPILE_FDB=true
 
 if [ -d third_party/forestdb ]; then
+    set +e
+    LAST_COMPILED_COMMIT=$(cat ./third_party/forestdb/build/last_compiled_commit)
+    set -e
     git submodule update
     pushd third_party/forestdb
-    if [ $(git rev-parse HEAD) == ${FORESTDB_COMMIT} ]; then
+    if [ ${LAST_COMPILED_COMMIT} == ${FORESTDB_COMMIT} ]; then
         RECOMPILE_FDB=false
     fi
     if [ ${FORCE_COMPILE_DEPENDENCIES} == true ]; then
@@ -29,7 +32,8 @@ if [ ${RECOMPILE_FDB} == true ]; then
     mkdir build
     cd build
     cmake -DSNAPPY_OPTION=Disable ../
-    make static_lib $1
+    make static_lib $1    
     cd ..
+    echo $(git rev-parse HEAD) > ./build/last_compiled_commit
 fi
 popd

--- a/src/cmd_handler.cc
+++ b/src/cmd_handler.cc
@@ -136,7 +136,8 @@ void CmdHandler::handleCmd(DBWrap* target_dbw) {
           { "logcachestats", HANDLER_BINDER( &CmdHandler::hLogCacheStats ) },
           { "getrecord", HANDLER_BINDER( &CmdHandler::hDumpKv ) },
           { "getmeta", HANDLER_BINDER( &CmdHandler::hDumpKv ) },
-          { "dumpvalue2file", HANDLER_BINDER( &CmdHandler::hDumpKv ) }
+          { "dumpvalue2file", HANDLER_BINDER( &CmdHandler::hDumpKv ) },
+          { "compactupto", HANDLER_BINDER( &CmdHandler::hCompactUpto ) }
         } );
 
     auto entry = handlers.find(tokens[0]);
@@ -345,6 +346,22 @@ std::string CmdHandler::hDumpKv(DBWrap* target_dbw,
         print_rec(rec_out, count);
     }
 
+    return ss.str();
+}
+
+std::string CmdHandler::hCompactUpto(DBWrap* target_dbw,
+                                     const std::vector<std::string>& tokens)
+{
+    std::stringstream ss;
+    if (tokens.size() < 2) {
+        ss << "too few arguments: compactupto <TABLE INDEX>\n";
+        return ss.str();
+    }
+
+    uint64_t table_idx_upto = std::stoul(tokens[1]);
+    target_dbw->db->compactIdxUpto(CompactOptions(), table_idx_upto);
+
+    ss << "set urgent compaction table index upto " << table_idx_upto << std::endl;
     return ss.str();
 }
 

--- a/src/cmd_handler.h
+++ b/src/cmd_handler.h
@@ -50,6 +50,9 @@ private:
     std::string hDumpKv(DBWrap* target_dbw,
                         const std::vector<std::string>& tokens);
 
+    std::string hCompactUpto(DBWrap* target_dbw,
+                             const std::vector<std::string>& tokens);
+
 };
 
 

--- a/src/compactor.cc
+++ b/src/compactor.cc
@@ -150,6 +150,9 @@ void Compactor::work(WorkerOptions* opt_base) {
                 continue;
             }
 
+            // Clear urgent copmaction by index if necessary.
+            dbwrap->db->p->tableMgr->autoClearUrgentCompactionTableIdx();
+
             // Currently all levels have even probability.
             // TODO: Give higher priority to upper levels?
             size_t num_levels = dbwrap->db->p->tableMgr->getNumLevels();

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -368,7 +368,6 @@ void DBMgr::setDebugParams(const DebugParams& to,
               "urgent compaction size %zu, "
               "urgent compaction ratio %zu, "
               "urgent compaction writes %zu, "
-              "urgent compaction max table idx %zu, "
               "rollback delay %zu",
               effective_time_sec,
               debugParams.compactionDelayUs,
@@ -376,7 +375,6 @@ void DBMgr::setDebugParams(const DebugParams& to,
               debugParams.urgentCompactionFilesize,
               debugParams.urgentCompactionRatio,
               debugParams.urgentCompactionNumWrites,
-              debugParams.urgentCompactionMaxTableIdx,
               debugParams.rollbackDelayUs);
 }
 

--- a/src/jungle.cc
+++ b/src/jungle.cc
@@ -524,6 +524,12 @@ Status DB::compactInplace(const CompactOptions& options,
     s = p->tableMgr->compactInPlace(options, nullptr, level, false);
     return s;
 }
+Status DB::compactIdxUpto(const CompactOptions& options,
+                          size_t idx_upto)
+{
+    p->tableMgr->setUrgentCompactionTableIdx(idx_upto);
+    return Status();
+}
 
 Status DB::splitLevel(const CompactOptions& options,
                       size_t level)

--- a/src/table_manifest.cc
+++ b/src/table_manifest.cc
@@ -655,6 +655,25 @@ Status TableManifest::getNumTables(size_t level, size_t& num_tables_out) const {
     return Status();
 }
 
+Status TableManifest::getSmallestTableIdx(uint64_t& idx_out) {
+    uint64_t cur_min = std::numeric_limits<uint64_t>::max();
+
+    for (auto& entry: levels) {
+        LevelInfo*& l_info = entry;
+        skiplist_node* cursor = skiplist_begin(l_info->tables);
+        while (cursor) {
+            TableInfo* t_info = _get_entry(cursor, TableInfo, snode);
+            cur_min = std::min(t_info->number, cur_min);
+
+            cursor = skiplist_next(l_info->tables, cursor);
+            skiplist_release_node(&t_info->snode);
+        }
+        if (cursor) skiplist_release_node(cursor);
+    }
+
+    idx_out = cur_min;
+    return Status();
+}
 
 } // namespace jungle
 

--- a/src/table_manifest.h
+++ b/src/table_manifest.h
@@ -204,6 +204,8 @@ public:
 
     Status getNumTables(size_t level, size_t& num_tables_out) const;
 
+    Status getSmallestTableIdx(uint64_t& idx_out);
+
     std::mutex& getLock() { return tableUpdateLock; }
 
     void setLogger(SimpleLogger* logger) { myLog = logger; }

--- a/src/table_mgr.h
+++ b/src/table_mgr.h
@@ -282,6 +282,17 @@ public:
 
     void resetNumWrittenRecords() { numWrittenRecords = 0; }
 
+    /**
+     * Set urgent compaction table index number to `to`.
+     */
+    void setUrgentCompactionTableIdx(uint64_t to);
+
+    /**
+     * If the smallest table index number is greater than
+     * the urgent compaction index number, clear it.
+     */
+    void autoClearUrgentCompactionTableIdx();
+
     static void doCompactionThrottling
                 (const GlobalConfig::CompactionThrottlingOptions& t_opt,
                  Timer& throttling_timer);
@@ -475,7 +486,9 @@ protected:
 // === VARIABLES
     const size_t APPROX_META_SIZE;
 
-    // Backward pointer to parent DB instance.
+    /**
+     * Backward pointer to parent DB instance.
+     */
     DB* parentDb;
 
     std::atomic<bool> allowCompaction;
@@ -490,23 +503,40 @@ protected:
 
     uint32_t numL0Partitions;
 
-    // Compaction status of L0 hash partitions.
+    /**
+     * Compaction status of L0 hash partitions.
+     */
     std::vector< std::atomic<bool>* > compactStatus;
 
-    // Number of on-going compactions in L1,
-    // only used for level extension mode.
+    /**
+     * Number of on-going compactions in L1,
+     * only used for level extension mode.
+     */
     std::atomic<size_t> numL1Compactions;
 
-    // Set of tables being compacted/merged/split.
+    /**
+     * Set of tables being compacted/merged/split.
+     */
     std::set<uint64_t> lockedTables;
     std::mutex lockedTablesLock;
 
-    // Set of (source) levels that interlevel compaction is in progress.
+    /**
+     * Set of (source) levels that interlevel compaction is in progress.
+     */
     std::unordered_set<size_t> lockedLevels;
     std::mutex lockedLevelsLock;
 
-    // Total accumulated number of records written to table.
+    /**
+     * Total accumulated number of records written to table.
+     */
     std::atomic<uint64_t> numWrittenRecords;
+
+    /**
+     * If non-zero, in-place compaction will be triggered sequentially,
+     * for tables whose index number is equal to or smaller than
+     * this number.
+     */
+    std::atomic<uint64_t> urgentCompactionMaxTableIdx;
 
     SimpleLogger* myLog;
 };

--- a/tests/bench/db_adapter_jungle.cc
+++ b/tests/bench/db_adapter_jungle.cc
@@ -192,10 +192,11 @@ int JungleAdapter::open(const std::string& db_file,
     (void)stats_out;
 
     jungle::DebugParams jungle_d_params;
-    jungle_d_params.urgentCompactionRatio = 500;
+    jungle_d_params.urgentCompactionRatio = 120;
     jungle_d_params.urgentCompactionNumWrites = 10000;
-    jungle_d_params.urgentCompactionMaxTableIdx = stats_out.maxTableIndex;
     //jungle::setDebugParams(jungle_d_params);
+
+    //myDb->compactIdxUpto(jungle::CompactOptions(), stats_out.maxTableIndex);
 
     return 0;
 }


### PR DESCRIPTION
* Since the table index number is local for each DB instance, while
debugging parameter is global, we should move it to TableMgr.