### PR TITLE
Fix to bug of failing level extension

### DIFF
--- a/src/table_compaction.cc
+++ b/src/table_compaction.cc
@@ -313,7 +313,7 @@ Status TableMgr::compactLevelItr(const CompactOptions& options,
     std::list<uint64_t> dummy_chk;
     std::list<LsmFlushResult> results;
 
-    if (num_new_tables && num_records_read) {
+    if (num_new_tables) {
         // Extend new level if needed.
         if (is_last_level) mani->extendLevel();
     }


### PR DESCRIPTION
* Even though there is no record from source level, we should extend
the level if there is more than one target table in destination level.