### PR TITLE
Support manual seq number for MemTable flush

### DIFF
--- a/src/log_file.cc
+++ b/src/log_file.cc
@@ -374,7 +374,7 @@ Status LogFile::get(const uint64_t chk,
     return Status();
 }
 
-Status LogFile::flushMemTable() {
+Status LogFile::flushMemTable(uint64_t upto) {
    touch();
    // Skip unnecessary flushing
    if (immutable && !fHandle && isSynced()) {
@@ -482,7 +482,7 @@ Status LogFile::flushMemTable() {
 
     RwSerializer rws(fOps, fHandle, true);
 
-    TC( mTable->flush(rws) );
+    TC( mTable->flush(rws, upto) );
     TC( mTable->appendFlushMarker(rws) );
 
     TC( fOps->flush(fHandle) );

--- a/src/log_file.h
+++ b/src/log_file.h
@@ -81,7 +81,7 @@ public:
                bool allow_flushed_log,
                bool allow_tombstone);
 
-    Status flushMemTable();
+    Status flushMemTable(uint64_t upto = NOT_INITIALIZED);
 
     Status purgeMemTable();
 

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -1014,7 +1014,7 @@ Status MemTable::findOffsetOfSeq(SimpleLogger* logger,
 }
 
 // MemTable flush: skiplist (memory) -> log file. (disk)
-Status MemTable::flush(RwSerializer& rws)
+Status MemTable::flush(RwSerializer& rws, uint64_t upto)
 {
     if (minSeqNum == NOT_INITIALIZED) {
         // No log in this file. Just do nothing and return OK.
@@ -1024,6 +1024,11 @@ Status MemTable::flush(RwSerializer& rws)
     // Write logs in a mutation order.
     // From `synced seq num` to `max seq num`
     uint64_t seqnum_upto = maxSeqNum;
+
+    // Manually given sequence number limit.
+    if (valid_number(upto) && upto < seqnum_upto) {
+        seqnum_upto = upto;
+    }
 
     // Flush never happened: start from min seq num
     // Otherwise: start from last sync seq num + 1

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -84,7 +84,7 @@ public:
                                   uint64_t& offset_out,
                                   uint64_t* padding_start_pos_out = nullptr);
 
-    Status flush(RwSerializer& rws);
+    Status flush(RwSerializer& rws, uint64_t upto = NOT_INITIALIZED);
     Status checkpoint(uint64_t& seq_num_out);
     Status getLogsToFlush(const uint64_t seq_num,
                           std::list<Record*>& list_out,


### PR DESCRIPTION
* If not given (default), flush all logs.