### PR TITLE
Stop loading log files once CRC error is detected

### DIFF
--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -357,7 +357,8 @@ Status LogManifest::load(const std::string& path,
                          min_seq, purged_seq, synced_seq);
         if (!s) {
             _s_warn(myLog) << "log file " << l_file_num << " read error: " << s;
-            if (s == Status::FILE_NOT_EXIST) {
+            if ( s == Status::FILE_NOT_EXIST ||
+                 s == Status::CHECKSUM_ERROR ) {
                 if ( !first_file_read &&
                      ii + 1 < num_log_files ) {
                     // If this is the first log file, and there are

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -150,8 +150,12 @@ void LogMgr::logMgrSettings() {
 
     GlobalConfig* g_conf = mgr->getGlobalConfig();
 
-    _log_info(myLog, "initialized log manager, memtable flush buffer %zu",
-              g_conf->memTableFlushBufferSize);
+    _log_info(myLog,
+              "initialized log manager, memtable flush buffer %zu, "
+              "direct-IO %s",
+              g_conf->memTableFlushBufferSize,
+              ( opt.dbConfig->directIoOpt.enabled
+                ? "ON" : "OFF" ) );
 }
 
 Status LogMgr::rollback(uint64_t seq_upto) {

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -585,6 +585,7 @@ Status MemTable::loadRecord(RwSerializer& rws,
     char local_comp_buf[LOCAL_COMP_BUF_SIZE];
 
     const size_t LEN_META_SIZE = getLengthMetaSize(flags);
+    uint64_t rec_offset = rws.pos();
 
   try{
     uint32_t crc_len = 0;
@@ -680,7 +681,9 @@ Status MemTable::loadRecord(RwSerializer& rws,
     }
 
     if (crc_data != crc_data_chk) {
-        _log_err(myLog, "crc error %x != %x", crc_data, crc_data_chk);
+        _log_err(myLog, "crc error %x (expected) != %x (actual), "
+                 "in the record starting at offset 0x%lx",
+                 crc_data, crc_data_chk, rec_offset - 8);
         throw Status(Status::CHECKSUM_ERROR);
     }
 


### PR DESCRIPTION
* Records after CRC error are likely corrupted as well.