### PR TITLE
Allow overwriting seq numbers after discard

### DIFF
--- a/src/log_manifest.h
+++ b/src/log_manifest.h
@@ -253,15 +253,20 @@ public:
                                const uint64_t e_log_inc,
                                std::vector<LogFileInfo*>& info_out,
                                bool force_not_load_memtable = false);
+
     Status getLogFileInfoBySeq(const uint64_t seq_num,
                                LogFileInfo*& info_out,
-                               bool force_not_load_memtable = false);
+                               bool force_not_load_memtable = false,
+                               bool ignore_max_seq_num = false);
+
     LogFileInfo* getLogFileInfoP(uint64_t log_num,
                                  bool force_not_load_memtable = false);
 
     Status getLogFileNumBySeq(const uint64_t seq_num,
                               uint64_t& log_file_num_out,
-                              bool force_not_load_memtable = false);
+                              bool force_not_load_memtable = false,
+                              bool ignore_max_seq_num = false);
+
     Status getMaxLogFileNum(uint64_t& log_file_num_out);
     Status setMaxLogFileNum(uint64_t cur_num, uint64_t new_num);
 

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -509,7 +509,13 @@ Status LogMgr::setSN(const Record& rec) {
         if ( valid_number(rec.seqNum) &&
              getDbConfig()->allowOverwriteSeqNum ) {
             // May overwrite existing seqnum, get corresponding log file.
-            s = mani->getLogFileNumBySeq(rec.seqNum, log_file_num);
+            // NOTE:
+            //   We should ignore max seqnum checking here,
+            //   as seq numbers may not be consecutive.
+            s = mani->getLogFileNumBySeq( rec.seqNum,
+                                          log_file_num,
+                                          false,
+                                          true );
             if (s) overwrite = true;
             // If not exist, use the latest file.
         }


### PR DESCRIPTION
* If users overwrite seq numbers, it should work even after discard.