### PR TITLE
Fix to bug that new log file is not created

### DIFF
--- a/include/libjungle/db_stats.h
+++ b/include/libjungle/db_stats.h
@@ -33,6 +33,8 @@ public:
         , numBgTasks(0)
         , minTableIndex(0)
         , maxTableIndex(0)
+        , minLogIndex(0)
+        , maxLogIndex(0)
         {}
 
     /**
@@ -93,6 +95,22 @@ public:
      * Greatest (i.e., youngest) table file index number.
      */
     uint64_t maxTableIndex;
+
+    /**
+     * [Local]
+     * Smallest (i.e., oldest) log file index number.
+     * This value can be `-1` if any error happens.
+     */
+    uint64_t minLogIndex;
+
+    /**
+     * [Local]
+     * Greatest (i.e., youngest) log file index number.
+     * This value can be `-1` if any error happens.
+     */
+    uint64_t maxLogIndex;
+
+
 };
 
 } // namespace jungle

--- a/src/jungle.cc
+++ b/src/jungle.cc
@@ -725,6 +725,8 @@ Status DB::getStats(DBStats& stats_out) {
     if (p) {
         if (p->logMgr) {
             stats_out.numOpenMemtables = p->logMgr->getNumMemtables();
+            stats_out.minLogIndex = p->logMgr->getMinLogFileIndex();
+            stats_out.maxLogIndex = p->logMgr->getMaxLogFileIndex();
         }
         stats_out.numBgTasks = p->getNumBgTasks();
     }

--- a/src/log_manifest.h
+++ b/src/log_manifest.h
@@ -257,7 +257,7 @@ public:
     Status getLogFileInfoBySeq(const uint64_t seq_num,
                                LogFileInfo*& info_out,
                                bool force_not_load_memtable = false,
-                               bool ignore_max_seq_num = false);
+                               bool allow_non_exact_match = false);
 
     LogFileInfo* getLogFileInfoP(uint64_t log_num,
                                  bool force_not_load_memtable = false);

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -1657,4 +1657,19 @@ size_t LogMgr::getNumLogFiles() {
     return mani->getNumLogFiles();
 }
 
+uint64_t LogMgr::getMinLogFileIndex() {
+    if (!initialized || !mani) return NOT_INITIALIZED;
+    uint64_t log_file_num_out = NOT_INITIALIZED;
+    mani->getMinLogFileNum(log_file_num_out);
+    return log_file_num_out;
+}
+
+uint64_t LogMgr::getMaxLogFileIndex() {
+    if (!initialized || !mani) return NOT_INITIALIZED;
+    uint64_t log_file_num_out = NOT_INITIALIZED;
+    mani->getMaxLogFileNum(log_file_num_out);
+    return log_file_num_out;
+}
+
 } // namespace jungle
+

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -200,6 +200,10 @@ public:
 
     size_t getNumLogFiles();
 
+    uint64_t getMinLogFileIndex();
+
+    uint64_t getMaxLogFileIndex();
+
     DB* getParentDb() const { return parentDb; }
 
     struct Iterator {


### PR DESCRIPTION
* There was a bug that if `allowOverwriteSeqNum` option is enabled,
new log file is not created and the last log file grows infinitely.

* Added new two fields to DB stats: min/max log file index number.