### PR TITLE
Fix to bug that gotoEnd/Begin hits non-valid node

### DIFF
--- a/src/internal_helper.h
+++ b/src/internal_helper.h
@@ -246,13 +246,13 @@ struct VerboseLog {
     if (!s) { m = msg; break; } \
 
 // Delete / free and clear the pointer.
-#define DELETE(ptr) \
-    delete ptr;     \
-    ptr = nullptr   \
+#define DELETE(ptr)         \
+    {   delete ptr;         \
+        ptr = nullptr;  }   \
 
-#define FREE(ptr)   \
-    free(ptr);      \
-    ptr = nullptr   \
+#define FREE(ptr)           \
+    {   free(ptr);          \
+        ptr = nullptr;  }   \
 
 // If-clause that can use `break` in the middle.
 #define IF(cond)                        \

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -121,9 +121,13 @@ bool MemTable::RecNode::validKeyExist( const uint64_t chk,
 
     if (valid_key_exist) {
         Record* rec = getLatestRecord(chk);
-        assert(rec);
-        if ( !allow_tombstone &&
-             !rec->isIns() ) {
+        if (!rec) {
+            // All records in the list may have
+            // higher sequence number than given `chk`.
+            // In such a case, `rec` can be `nullptr`.
+            valid_key_exist = false;
+        } else if ( !allow_tombstone &&
+                    !rec->isIns() ) {
             // Record exists, but latest one is not an insert,
             // and doesn't allow tombstone.
             valid_key_exist = false;

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -146,6 +146,10 @@ public:
             BY_KEY = 0,
             BY_SEQ = 1
         } type;
+
+        skiplist_node* findFirstValidNode(skiplist_node* seek_node,
+                                          bool fwd_search);
+
         const MemTable* mTable;
         skiplist_node* cursor;
         uint64_t minSeq;


### PR DESCRIPTION
* On gotoEnd(), the records in the last node in the iterator may have
higher sequence number than the iterator has. In such a case, there
is no valid record in the node, hence we should do backward search
until we find the first valid node. Otherwise, crash happens in the
following get() API due to null record.

* Same to gotoBegin().