### PR TITLE
Support immediate purging for deleted records

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -112,6 +112,7 @@ public:
         , readOnly(false)
         , preFlushDirtyInterval_sec(5)
         , numExpectedUserThreads(8)
+        , purgeDeletedDocImmediately(true)
     {
         tableSizeRatio.push_back(2.5);
         levelSizeRatio.push_back(10.0);
@@ -452,6 +453,13 @@ public:
      * performance and resource usage.
      */
     uint32_t numExpectedUserThreads;
+
+    /**
+     * If `true`, deleted records will purged as soon as it
+     * is merged into the bottom-most level. After that,
+     * its meta data will not be retrieved even with `meta_only` flag.
+     */
+    bool purgeDeletedDocImmediately;
 };
 
 class GlobalConfig {

--- a/src/table_file.h
+++ b/src/table_file.h
@@ -120,7 +120,8 @@ public:
     Status setSingle(uint32_t key_hash_val,
                      const Record& rec,
                      uint64_t& offset_out,
-                     bool set_as_it_is = false);
+                     bool set_as_it_is = false,
+                     bool is_last_level = false);
 
     Status setBatch(std::list<Record*>& batch,
                     std::list<uint64_t>& checkpoints,
@@ -256,6 +257,8 @@ public:
 
     Status returnSnapshot(Snapshot* snapshot);
 
+    TableInfo* getTableInfo() const { return tableInfo; }
+
 private:
 // === TYPES
     /**
@@ -326,6 +329,9 @@ private:
     static void rawMetaToUserMeta(const SizedBuf& raw_meta,
                                   InternalMeta& internal_meta_out,
                                   SizedBuf& user_meta_out);
+
+    static void readInternalMeta(const SizedBuf& raw_meta,
+                                 InternalMeta& internal_meta_out);
 
     static uint32_t tfExtractFlags(const SizedBuf& raw_meta);
 

--- a/src/table_manifest.cc
+++ b/src/table_manifest.cc
@@ -543,6 +543,8 @@ Status TableManifest::getTablesPoint(const size_t level,
             // If `hash_len` is given, use prefix only.
             SizedBuf data_to_hash(hash_len, key.data);
             target_hash = getMurmurHash(data_to_hash, target_hash);
+        } else {
+            target_hash = getMurmurHash(key, target_hash);
         }
         return getTablesByHash(l_info, target_hash, tables_out);
 

--- a/src/table_mgr.cc
+++ b/src/table_mgr.cc
@@ -82,13 +82,16 @@ void TableMgr::logTableSettings(const DBConfig* db_config) {
     if (db_config->compactionFactor) {
         _log_info( myLog, "compaction factor %u, reuse factor %zu, "
                    "num writes to compact %zu, "
-                   "min file size %zu, cycle at least %u at most %u",
+                   "min file size %zu, cycle at least %u at most %u, "
+                   "tombstones: %s",
                    db_config->compactionFactor,
                    db_config->blockReuseFactor,
                    db_config->numWritesToCompact,
                    db_config->minFileSizeToCompact,
                    db_config->minBlockReuseCycleToCompact,
-                   db_config->maxBlockReuseCycle );
+                   db_config->maxBlockReuseCycle,
+                   db_config->purgeDeletedDocImmediately
+                   ? "purge immediately" : "keep until compaction");
     } else {
         _log_info(myLog, "auto compaction is disabled");
     }

--- a/src/table_set_batch.cc
+++ b/src/table_set_batch.cc
@@ -63,6 +63,10 @@ void TableMgr::setTableFileOffset( std::list<uint64_t>& checkpoints,
     DBMgr* mgr = DBMgr::getWithoutInit();
     DebugParams d_params = mgr->getDebugParams();
 
+    size_t num_levels = mani->getNumLevels();
+    size_t dst_level = (dst_file && dst_file->getTableInfo()) ?
+                       dst_file->getTableInfo()->level : 0;
+
     const GlobalConfig* global_config = mgr->getGlobalConfig();
     const GlobalConfig::CompactionThrottlingOptions& t_opt =
         global_config->ctOpt;
@@ -103,7 +107,8 @@ void TableMgr::setTableFileOffset( std::list<uint64_t>& checkpoints,
         //   Since `rec_out` from `getByOffset` contains raw meta and
         //   compressed value (if enabled), we should skip processing
         //   meta and compression.
-        dst_file->setSingle(key_hash_val, rec_out, offset_out, true);
+        dst_file->setSingle(key_hash_val, rec_out, offset_out,
+                            true, dst_level + 1 == num_levels);
 
         if (d_params.compactionItrScanDelayUs) {
             // If debug parameter is given, sleep here.

--- a/src/table_split.cc
+++ b/src/table_split.cc
@@ -371,7 +371,8 @@ Status TableMgr::mergeLevel(const CompactOptions& options,
                             TableInfo* victim_table,
                             size_t level)
 {
-    if (level == 0 || level >= mani->getNumLevels()) return Status::INVALID_LEVEL;
+    size_t num_levels = mani->getNumLevels();
+    if (level == 0 || level >= num_levels) return Status::INVALID_LEVEL;
     if ( victim_table &&
          victim_table->level != level ) return Status::INVALID_PARAMETERS;
 
@@ -459,7 +460,8 @@ Status TableMgr::mergeLevel(const CompactOptions& options,
 
         uint32_t key_hash_val = getMurmurHash32(rec_out.kv.key);;
         uint64_t offset_out = 0; // not used.
-        target_table->file->setSingle(key_hash_val, rec_out, offset_out);
+        target_table->file->setSingle(key_hash_val, rec_out, offset_out,
+                                      false, level + 1 == num_levels);
         total_count++;
     } while (itr->next().ok());
     itr->close();

--- a/tests/jungle/basic_op_test.cc
+++ b/tests/jungle/basic_op_test.cc
@@ -2702,6 +2702,77 @@ int kmv_get_memory_test() {
     return 0;
 }
 
+int immediate_purging_test() {
+    std::string filename;
+    TEST_SUITE_PREPARE_PATH(filename);
+
+    jungle::DB* db;
+    jungle::Status s;
+
+    // Open DB.
+    jungle::DBConfig config;
+    TEST_CUSTOM_DB_CONFIG(config);
+    config.purgeDeletedDocImmediately = true;
+    CHK_Z( jungle::DB::open(&db, filename, config) );
+
+    for (size_t ii = 0; ii < 10000; ++ii) {
+        jungle::Record rec;
+        std::string key_str = "key" + TestSuite::lzStr(5, ii);
+        std::string meta_str = "meta" + TestSuite::lzStr(5, ii);
+        std::string value_str = "value" + TestSuite::lzStr(5, ii);
+        rec.kv.key = jungle::SizedBuf(key_str);
+        rec.kv.value = jungle::SizedBuf(value_str);
+        rec.meta = jungle::SizedBuf(meta_str);
+        CHK_Z( db->setRecordByKey(rec) );
+    }
+
+    CHK_Z( db->sync(false) );
+    CHK_Z( db->flushLogs() );
+    for (size_t ii = 0; ii < 4; ++ii) {
+        CHK_Z( db->compactL0(jungle::CompactOptions(), ii) );
+    }
+
+    auto verify_func = [&](bool after_deletion) -> int {
+        for (size_t ii = 0; ii < 10000; ++ii) {
+            TestSuite::setInfo("ii == %zu", ii);
+            jungle::Record rec;
+            std::string key_str = "key" + TestSuite::lzStr(5, ii);
+            std::string meta_str = "meta" + TestSuite::lzStr(5, ii);
+            std::string value_str = "value" + TestSuite::lzStr(5, ii);
+            jungle::Record rec_out;
+            jungle::Record::Holder h_rec_out(rec_out);
+            s = db->getRecordByKey(jungle::SizedBuf(key_str), rec_out);
+            if (after_deletion && ii % 2 == 0) {
+                CHK_GT(0, s);
+            } else {
+                CHK_Z(s);
+            }
+        }
+        return 0;
+    };
+    CHK_Z( verify_func(false) );
+
+    for (size_t ii = 0; ii < 10000; ii += 2) {
+        jungle::Record rec;
+        std::string key_str = "key" + TestSuite::lzStr(5, ii);
+        CHK_Z( db->del( jungle::SizedBuf(key_str) ) );
+    }
+    CHK_Z( verify_func(true) );
+
+    CHK_Z( db->sync(false) );
+    CHK_Z( db->flushLogs() );
+    for (size_t ii = 0; ii < 4; ++ii) {
+        CHK_Z( db->compactL0(jungle::CompactOptions(), ii) );
+    }
+    CHK_Z( verify_func(true) );
+
+    CHK_Z( jungle::DB::close(db) );
+    CHK_Z( jungle::shutdown() );
+
+    TEST_SUITE_CLEANUP_PATH();
+    return 0;
+}
+
 int main(int argc, char** argv) {
     TestSuite ts(argc, argv);
 
@@ -2753,6 +2824,7 @@ int main(int argc, char** argv) {
     ts.doTest("get by prefix test",
               get_by_prefix_test, TestRange<size_t>( {0, 8, 16} ));
     ts.doTest("kmv get memory test", kmv_get_memory_test);
+    ts.doTest("immediate purging test", immediate_purging_test);
 
     return 0;
 }


### PR DESCRIPTION
* Once this option is enabled, the bottom-most level will not keep
tombstones but will immediately remove them from the index.