### PR TITLE
Fix to incorrect skiplist release

### DIFF
--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -783,7 +783,7 @@ Status LogManifest::removeLogFile(uint64_t log_num) {
     skiplist_wait_for_free(&info->snode);
 
     skiplist_erase_node(&logFilesBySeq, &info->snodeBySeq);
-    skiplist_wait_for_free(&info->snode);
+    skiplist_wait_for_free(&info->snodeBySeq);
 
     return Status();
 }


### PR DESCRIPTION
* The old code was waiting for incorrect skiplist node. May cause
heap-use-after-free.