### PR TITLE
Do not purge cached data after in-place compaction

### DIFF
--- a/src/table_file.h
+++ b/src/table_file.h
@@ -159,7 +159,10 @@ public:
     bool isFdbDocTombstone(fdb_doc* doc);
 
     Status compactTo(const std::string& dst_filename,
-                     const CompactOptions& options);
+                     const CompactOptions& options,
+                     void*& dst_handle_out);
+
+    void releaseDstHandle(void* void_handle);
 
     Status mergeCompactTo(const std::string& file_to_merge,
                           const std::string& dst_filename,
@@ -355,7 +358,8 @@ private:
 
     Status compactToManully(FdbHandle* compact_handle,
                             const std::string& dst_filename,
-                            const CompactOptions& options);
+                            const CompactOptions& options,
+                            void*& dst_handle_out);
 
 // === VARIABLES
     // File name.


### PR DESCRIPTION
* The handle for the destination file shouldn't be closed until the
new file is officially opened by the Table manager. Otherwise, its
reference count becomes zero so that all cached data is purged and
then re-loaded which causes unnecessary disk reads.