### PR TITLE
Add an option for pre-flushing by size

### DIFF
--- a/src/table_file.h
+++ b/src/table_file.h
@@ -385,11 +385,6 @@ private:
                             const CompactOptions& options,
                             void*& dst_handle_out);
 
-    Status compactToManullyFastScan(FdbHandle* compact_handle,
-                                    const std::string& dst_filename,
-                                    const CompactOptions& options,
-                                    void*& dst_handle_out);
-
 // === VARIABLES
     // File name.
     std::string filename;

--- a/src/table_mgr.cc
+++ b/src/table_mgr.cc
@@ -130,6 +130,10 @@ void TableMgr::logTableSettings(const DBConfig* db_config) {
         _log_info( myLog, "ratio: %s", ratio_str.c_str() );
     }
 
+    _log_info( myLog, "pre flush condition %zu sec, %zu bytes",
+               db_config->preFlushDirtyInterval_sec,
+               db_config->preFlushDirtySize );
+
     DBMgr* mgr = DBMgr::getWithoutInit();
     if (mgr) {
         GlobalConfig* g_conf = mgr->getGlobalConfig();

--- a/tests/bench/db_adapter_jungle.cc
+++ b/tests/bench/db_adapter_jungle.cc
@@ -154,6 +154,8 @@ int JungleAdapter::open(const std::string& db_file,
     config.fastIndexScan = true;
     _jbool(config.fastIndexScan, configObj, "fast_index_scan");
 
+    _jint(config.preFlushDirtySize, configObj, "pre_flush_dirty_size");
+
     uint64_t table_size_mb = 1024;
     _jint(table_size_mb, configObj, "l0_table_size_mb");
     config.maxL0TableSize = table_size_mb * 1024 * 1024;


### PR DESCRIPTION
* Flushing big data in sequential is good for IO performance as well
as write amplification, but it makes latency surge at the moment, which
is bad for server applications whose latency is critical.

* To avoid big flush, added more fine-grained option to flush dirty
data periodically by size.