### PR TITLE
Add background job for fixing manifest table range mismatch

### DIFF
--- a/include/libjungle/sized_buf.h
+++ b/include/libjungle/sized_buf.h
@@ -234,7 +234,7 @@ public:
         return !operator<(l, r);
     }
 
-    #define MSG_MAX 24
+    #define MSG_MAX 48
     /**
      * Print the contents of the given SizedBuf with readable
      * (i.e., ASCII printable) characters.

--- a/src/compactor.cc
+++ b/src/compactor.cc
@@ -245,6 +245,10 @@ void Compactor::work(WorkerOptions* opt_base) {
                 s = target_db->p->tableMgr->compactInPlace
                     ( c_opt, target_table, target_level, true );
 
+            } else if ( target_strategy == TableMgr::FIX ) {
+                s = target_db->p->tableMgr->fixTable
+                    ( c_opt, target_table, target_level );
+
             } else {
                 assert(0);
             }

--- a/src/table_file.h
+++ b/src/table_file.h
@@ -121,7 +121,8 @@ public:
                      const Record& rec,
                      uint64_t& offset_out,
                      bool set_as_it_is = false,
-                     bool is_last_level = false);
+                     bool is_last_level = false,
+                     bool force_delete = false);
 
     Status setBatch(std::list<Record*>& batch,
                     std::list<uint64_t>& checkpoints,
@@ -214,6 +215,8 @@ public:
     const std::string& getName() const { return filename; }
 
     uint64_t getNumber() const { return myNumber; }
+
+    Status getMinKey(SizedBuf& min_key_out);
 
     Status getMaxKey(SizedBuf& max_key_out);
 

--- a/src/table_manifest.h
+++ b/src/table_manifest.h
@@ -62,6 +62,7 @@ struct TableInfo {
         , status( query_purpose ? QUERY_PURPOSE : NORMAL )
         , stack(nullptr)
         , baseTable(true)
+        , prevTableSearchRequired(false)
     {
         if (query_purpose) return;
         skiplist_init_node(&snode);
@@ -72,6 +73,9 @@ struct TableInfo {
         minKey.free();
         delete stack.load();
         stack = nullptr;
+        if (refCount.load()) {
+            assert(refCount.load() == 0);
+        }
         assert(refCount.load() == 0);
     }
 
@@ -158,6 +162,10 @@ struct TableInfo {
     // `true` if this table is the owner of stack.
     // `false` if this table belongs to the stack of other table.
     bool baseTable;
+
+    // If `true`, there is a problem with manifest.
+    // Get or iterate should search its previous table as well.
+    std::atomic<bool> prevTableSearchRequired;
 };
 
 class TableManifest {

--- a/src/table_mgr.h
+++ b/src/table_mgr.h
@@ -149,6 +149,7 @@ public:
         INPLACE = 0x3,
         MERGE = 0x4,
         INPLACE_OLD = 0x5,
+        FIX = 0x6,
     };
 
     Status init(const TableMgrOptions& _options);
@@ -204,6 +205,8 @@ public:
                            uint64_t& wss_out,
                            uint64_t& total_out);
 
+    Status pickTableToFix(size_t level, TableInfo*& victim_table_out);
+
     TableInfo* findLocalVictim(size_t level,
                                TableInfo* given_victim,
                                VictimPolicy policy,
@@ -216,6 +219,10 @@ public:
     Status mergeLevel(const CompactOptions& options,
                       TableInfo* victim_table,
                       size_t level);
+
+    Status fixTable(const CompactOptions& options,
+                    TableInfo* victim_table,
+                    size_t level);
 
     Status compactLevelItr(const CompactOptions& options,
                            TableInfo* victim_table,


### PR DESCRIPTION
* If there is a mismatch between table manifest and actual table range,
move records to the correct table.