### PR TITLE
Revert change for sorting records for log flush

### DIFF
--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -1237,7 +1237,6 @@ Status LogMgr::flush(const FlushOptions& options,
 
     Status s;
     Timer tt;
-    const DBConfig* db_config = getDbConfig();
 
     // Grab all logs and pass them to table manager
     uint64_t ln_from, ln_to, ln_to_original;
@@ -1323,6 +1322,15 @@ Status LogMgr::flush(const FlushOptions& options,
         parentDb->p->flags.seqLoading = increasing_order;
 
         if (records.size()) {
+#if 0
+            // NOTE:
+            //   Sorting records in a key order will not help,
+            //   because there is a seq-index in table file.
+            //   Sorting records by key makes them random for seq-index,
+            //   thus there is no benefit.
+            //
+            //   Need to re-visit this logic later.
+            const DBConfig* db_config = getDbConfig();
             if (!increasing_order && db_config->preFlushDirtySize) {
                 auto less_records = [](const Record* ll, const Record* rr) -> bool {
                     return (ll->kv.key < rr->kv.key);
@@ -1335,7 +1343,7 @@ Status LogMgr::flush(const FlushOptions& options,
                 //   Sorting `records` discards checkpoint info.
                 checkpoints.clear();
             }
-
+#endif
             EP( table_mgr->setBatch(records, checkpoints) );
             EP( table_mgr->storeManifest() );
             _log_debug(myLog, "Updated table files.");


### PR DESCRIPTION
* Reverted the change added recently:
https://github.com/eBay/Jungle/pull/109/files#diff-3a78ea2725a657dcdbe49cbad743cc2de9c82b14b4218546e86e32c91788ab91R1326-R1338

* Sorting records in a key order will not help, because there is a
seq-index in table file. Sorting records by key makes them random
for seq-index, thus there is no benefit.