### PR TITLE
avoid to close a closed iterator

### DIFF
--- a/src/iterator.cc
+++ b/src/iterator.cc
@@ -566,7 +566,7 @@ bool Iterator::IteratorInternal::checkValidByKey(ItrInt::ItrItem* item,
 }
 
 Status Iterator::close() {
-    if (p) {
+    if (p && p->db) {
         avl_node* cursor = avl_first(&p->curWindow);
         while (cursor) {
             ItrInt::ItrItem* item = _get_entry(cursor, ItrInt::ItrItem, an);


### PR DESCRIPTION
Such code will crash.
```
StorageEngineJungle::KeyItr::close() {
    if (itr) {
        itr->close();
        DELETE(itr);
    }
    if (snap) {
        DB::close(snap);
        snap = nullptr;
    }
}
```
#27 0x0000563511a97527 in SimpleLoggerMgr::handleSegFault (sig=11) at 
#28 <signal handler called>
#29 0x0000563511f9202b in jungle::Iterator::close (this=this@entry=0xd856) at 
#30 0x0000563511f92129 in jungle::Iterator::~Iterator (this=0xd856, __in_chrg=<optimized out>) 