### PR TITLE
Fix to bug of hanging thread during removing log file

### DIFF
--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -552,6 +552,14 @@ public:
     static DebugParams getDebugParams();
 
     /**
+     * Enable callback functions given by debugging parameters.
+     *
+     * @param enable If `true`, callbacks are enabled.
+     * @return Old value.
+     */
+    static bool enableDebugCallbacks(bool enable);
+
+    /**
      * Set the level of debugging log file (i.e., `system_logs.log`).
      *
      * Log level follows that in SimpleLogger:

--- a/include/libjungle/params.h
+++ b/include/libjungle/params.h
@@ -174,6 +174,7 @@ struct DebugParams {
         , tableSetBatchCb(nullptr)
         , addNewLogFileCb(nullptr)
         , newLogBatchCb(nullptr)
+        , getLogFileInfoBySeqCb(nullptr)
         , forceMerge(false)
         {}
 
@@ -253,6 +254,13 @@ struct DebugParams {
      * visible.
      */
     std::function< void(const GenericCbParams&) > newLogBatchCb;
+
+    /**
+     * Callback function that will be invoked right after the log
+     * file for the given sequence number is found from skiplist, but
+     * before checking the max sequence number of the file.
+     */
+    std::function< void(const GenericCbParams&) > getLogFileInfoBySeqCb;
 
     /**
      * If true, merge will proceed the task even with the small number

--- a/src/compactor.cc
+++ b/src/compactor.cc
@@ -168,7 +168,7 @@ void Compactor::work(WorkerOptions* opt_base) {
             }
 
             uint64_t num_writes_to_compact = db_config.numWritesToCompact;
-            if ( dbm->isDebugParamsEffective() &&
+            if ( dbm->isDebugParamEffective() &&
                  dbm->getDebugParams().urgentCompactionNumWrites ) {
                 if (!num_writes_to_compact) {
                     num_writes_to_compact =

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -158,9 +158,12 @@ DBMgr::DBMgr()
     , fQueue(new FlusherQueue())
     , twMgr(new TableWriterMgr())
     , gbExecutor(new GlobalBatchExecutor())
+    , debugCbEnabled(false)
     , idleTraffic(false)
     , myLog(nullptr)
 {
+    updateGlobalTime();
+
     skiplist_init(&dbMap, DBWrap::cmp);
 
     for (size_t ii = 0; ii < MAX_OP_HISTORY; ++ii) {

--- a/src/db_mgr.h
+++ b/src/db_mgr.h
@@ -130,7 +130,15 @@ public:
         return debugParams;
     }
 
-    bool isDebugParamsEffective() const { return !debugParamsTimer.timeout(); }
+    bool enableDebugCallbacks(bool new_value) {
+        bool old_value = debugCbEnabled.load(MOR);
+        debugCbEnabled.store(new_value, MOR);
+        return old_value;
+    }
+
+    bool isDebugParamEffective() const { return !debugParamsTimer.timeout(); }
+
+    bool isDebugCallbackEffective() const { return debugCbEnabled.load(MOR); }
 
 private:
     DBMgr();
@@ -171,6 +179,7 @@ private:
     DebugParams debugParams;
     std::mutex debugParamsLock;
     Timer debugParamsTimer;
+    std::atomic<bool> debugCbEnabled;
 
     // For async timer purpose.
     simple_thread_pool::ThreadPoolMgr tpMgr;

--- a/src/jungle.cc
+++ b/src/jungle.cc
@@ -907,6 +907,12 @@ DebugParams DB::getDebugParams() {
     return mgr->getDebugParams();
 }
 
+bool DB::enableDebugCallbacks(bool enable) {
+    DBMgr* mgr = DBMgr::getWithoutInit();
+    if (!mgr) return false;
+    return mgr->enableDebugCallbacks(enable);
+}
+
 // === Internal ================================================================
 
 DB::DBInternal::DBInternal()

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -557,10 +557,12 @@ Status LogMgr::setSN(const Record& rec) {
         addNewLogFile(g_li, g_li);
 
         DBMgr* dbm = DBMgr::getWithoutInit();
-        DebugParams dp = dbm->getDebugParams();
-        if (dp.addNewLogFileCb) {
-            DebugParams::GenericCbParams p;
-            dp.addNewLogFileCb(p);
+        if (dbm && dbm->isDebugCallbackEffective()) {
+            DebugParams dp = dbm->getDebugParams();
+            if (dp.addNewLogFileCb) {
+                DebugParams::GenericCbParams p;
+                dp.addNewLogFileCb(p);
+            }
         }
     }
 
@@ -708,7 +710,6 @@ Status LogMgr::setMultiInternal(const std::list<Record>& batch,
 {
     Status s;
     DBMgr* dbm = DBMgr::getWithoutInit();
-    DebugParams dp = dbm->getDebugParams();
 
     // Get latest log file.
     uint64_t max_log_file_num = 0;
@@ -728,8 +729,11 @@ Status LogMgr::setMultiInternal(const std::list<Record>& batch,
     }
     max_seq_out = g_li->file->getMaxSeqNum();
 
-    if (dp.newLogBatchCb) {
-        dp.newLogBatchCb(DebugParams::GenericCbParams());
+    if (dbm && dbm->isDebugCallbackEffective()) {
+        DebugParams dp = dbm->getDebugParams();
+        if (dp.newLogBatchCb) {
+            dp.newLogBatchCb(DebugParams::GenericCbParams());
+        }
     }
     numSetRecords.fetch_add(batch.size());
     return Status();

--- a/src/table_compact_condition.cc
+++ b/src/table_compact_condition.cc
@@ -46,7 +46,7 @@ Status TableMgr::pickVictimTable(size_t level,
     DBMgr* db_mgr = DBMgr::getWithoutInit();
     GlobalConfig* g_config = db_mgr->getGlobalConfig();
     DebugParams d_params = db_mgr->getDebugParams();
-    bool d_params_effective = db_mgr->isDebugParamsEffective();
+    bool d_params_effective = db_mgr->isDebugParamEffective();
 
     const DBConfig* db_config = getDbConfig();
     uint64_t MAX_TABLE_SIZE = db_config->getMaxTableSize(level);
@@ -457,7 +457,7 @@ bool TableMgr::chkL0CompactCond(uint32_t hash_num) {
     DBMgr* db_mgr = DBMgr::getWithoutInit();
     GlobalConfig* g_config = db_mgr->getGlobalConfig();
     DebugParams d_params = db_mgr->getDebugParams();
-    bool d_params_effective = db_mgr->isDebugParamsEffective();
+    bool d_params_effective = db_mgr->isDebugParamEffective();
 
     // Urgent compaction:
     //   => If block reuse cycle goes beyond 2x of threshold,

--- a/src/table_set_batch.cc
+++ b/src/table_set_batch.cc
@@ -280,7 +280,9 @@ Status TableMgr::setBatchHash( std::list<Record*>& batch,
             }
         }
 
-        if (d_params.tableSetBatchCb) {
+        if ( db_mgr &&
+             db_mgr->isDebugCallbackEffective() &&
+             d_params.tableSetBatchCb ) {
             DebugParams::GenericCbParams p;
             d_params.tableSetBatchCb(p);
         }

--- a/tests/jungle/corruption_test.cc
+++ b/tests/jungle/corruption_test.cc
@@ -806,7 +806,8 @@ int incomplete_table_set_test() {
             }
             TestSuite::_msg("flush\n");
         };
-    db->setDebugParams(d_params);
+    jungle::DB::setDebugParams(d_params);
+    jungle::DB::enableDebugCallbacks(true);
 
     const size_t NUM = 1000;
 

--- a/tests/jungle/snapshot_test.cc
+++ b/tests/jungle/snapshot_test.cc
@@ -1110,6 +1110,7 @@ int race_with_set_batch() {
         return 0;
     };
     jungle::DB::setDebugParams(dp);
+    jungle::DB::enableDebugCallbacks(true);
 
     // Put 10 records atomically.
     std::list<jungle::Record> recs;


### PR DESCRIPTION
* If `setSN` and `getSN` are called concurrently so that `getSN` sees
the new log with a higher sequence number, it will check if there is any
new file by calling `skiplist_next`. However, it doesn't release the
skiplist node so that its reference count doesn't decrease. It becomes
a problem when we remove that log file; since its reference count can't
be zero, the thread is hanging there forever.

* Added a new callback function for debugging.