### PR TITLE
Add a callback function for custom hash length

### DIFF
--- a/src/bloomfilter.cc
+++ b/src/bloomfilter.cc
@@ -56,6 +56,12 @@ void BloomFilter::set(void* data, size_t len) {
     }
 }
 
+void BloomFilter::set(uint64_t* hash_pair) {
+    for (size_t ii=0; ii<hashCount; ++ii) {
+        bitmap.set( gen_hash(ii, hash_pair) % bitmap.size(), true );
+    }
+}
+
 bool BloomFilter::check(void* data, size_t len) {
     uint64_t hash_pair[2] = {0, 0};
     get_hash_pair(data, len, hash_pair);

--- a/src/bloomfilter.h
+++ b/src/bloomfilter.h
@@ -38,6 +38,11 @@ public:
     void set(void* data, size_t len);
 
     /**
+     * Set the filter with the given pre-calculated hash pair.
+     */
+    void set(uint64_t* hash_pair);
+
+    /**
      * Check if the filter is positive with the given binary.
      */
     bool check(void* data, size_t len);

--- a/src/log_file.cc
+++ b/src/log_file.cc
@@ -362,14 +362,13 @@ Status LogFile::getSN(const uint64_t seq_num, Record& rec_out) {
 
 Status LogFile::get(const uint64_t chk,
                     const SizedBuf& key,
-                    uint64_t* key_hash,
                     Record& rec_out,
                     bool allow_flushed_log,
                     bool allow_tombstone)
 {
     touch();
     Status s;
-    EP( mTable->getRecordByKey(chk, key, key_hash, rec_out,
+    EP( mTable->getRecordByKey(chk, key, rec_out,
                                allow_flushed_log, allow_tombstone) );
     return Status();
 }
@@ -391,14 +390,13 @@ Status LogFile::getNearest(const uint64_t chk,
 
 Status LogFile::getPrefix(const uint64_t chk,
                           const SizedBuf& prefix,
-                          uint64_t* prefix_hash,
                           SearchCbFunc cb_func,
                           bool allow_flushed_log,
                           bool allow_tombstone)
 {
     touch();
     Status s;
-    EP( mTable->getRecordsByPrefix(chk, prefix, prefix_hash, cb_func,
+    EP( mTable->getRecordsByPrefix(chk, prefix, cb_func,
                                    allow_flushed_log, allow_tombstone) );
     return Status();
 }

--- a/src/log_file.h
+++ b/src/log_file.h
@@ -76,7 +76,6 @@ public:
     // Returns pointer only.
     Status get(const uint64_t chk,
                const SizedBuf& key,
-               uint64_t* key_hash,
                Record& rec_out,
                bool allow_flushed_log,
                bool allow_tombstone);
@@ -90,7 +89,6 @@ public:
 
     Status getPrefix(const uint64_t chk,
                      const SizedBuf& prefix,
-                     uint64_t* prefix_hash,
                      SearchCbFunc cb_func,
                      bool allow_flushed_log,
                      bool allow_tombstone);

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -60,7 +60,6 @@ public:
     // Returns pointer only.
     Status getRecordByKey(const uint64_t chk,
                           const SizedBuf& key,
-                          uint64_t* key_hash,
                           Record& rec_out,
                           bool allow_flushed_log,
                           bool allow_tombstone);
@@ -72,7 +71,6 @@ public:
                                  SearchOptions s_opt);
     Status getRecordsByPrefix(const uint64_t chk,
                               const SizedBuf& prefix,
-                              uint64_t* prefix_hash,
                               SearchCbFunc cb_func,
                               bool allow_flushed_log,
                               bool allow_tombstone);
@@ -214,8 +212,6 @@ private:
                                   bool allow_tombstone,
                                   SearchOptions s_opt);
 
-    size_t getHashLen(size_t len);
-
 // === VARIABLES
     uint64_t startSeqNum;
 
@@ -242,8 +238,7 @@ private:
     skiplist_raw* idxByKey;
     // Bloom filter for key.
     BloomFilter* bfByKey;
-    // Cache of `keyLenLimitForHash`.
-    size_t bfKeyLenLimit;
+    //size_t bfKeyLenLimit;
 
     // Temporary store for stale (overwritten using the same seq num) logs.
     std::mutex staleLogsLock;

--- a/src/table_mgr.cc
+++ b/src/table_mgr.cc
@@ -56,15 +56,7 @@ TableMgr::~TableMgr() {
 }
 
 uint32_t TableMgr::getKeyHash(const SizedBuf& key) const {
-    size_t target_size = key.size;
-    if ( opt.dbConfig->keyLenLimitForHash &&
-         target_size > opt.dbConfig->keyLenLimitForHash ) {
-        // If `keyLenLimitForHash` is given, AND
-        // key length is longer than `keyLenLimitForHash`,
-        // calculate the hash only on the given length.
-        target_size = opt.dbConfig->keyLenLimitForHash;
-    }
-    SizedBuf data_to_hash(target_size, key.data);
+    SizedBuf data_to_hash = get_data_to_hash(opt.dbConfig, key, false);
     return getMurmurHash32(data_to_hash);
 }
 

--- a/tests/bench/db_adapter_jungle.cc
+++ b/tests/bench/db_adapter_jungle.cc
@@ -132,7 +132,17 @@ int JungleAdapter::open(const std::string& db_file,
 
     jungle::DBConfig config;
     TEST_CUSTOM_DB_CONFIG(config);
-    _jint(config.keyLenLimitForHash, configObj, "key_len_limit_for_hash");
+
+    size_t suffix_len = 0;
+    _jint(suffix_len, configObj, "suffix_len_ruled_out_from_hash");
+    if (suffix_len) {
+        config.customLenForHash = [suffix_len]
+                                  (const jungle::HashKeyLenParams& params) -> size_t {
+            if (params.isPartialKey) return params.key.size;
+            if (params.key.size > suffix_len) return params.key.size - suffix_len;
+            return params.key.size;
+        };
+    }
 
     _jint(config.throttlingNumLogFilesSoft, configObj, "throttling_num_log_files_soft");
     _jint(config.throttlingNumLogFilesHard, configObj, "throttling_num_log_files_hard");

--- a/tests/jungle/basic_op_test.cc
+++ b/tests/jungle/basic_op_test.cc
@@ -2542,7 +2542,9 @@ int get_by_prefix_test(size_t hash_len) {
     jungle::DB* db;
 
     config.maxEntriesInLogFile = 20;
-    config.keyLenLimitForHash = hash_len;
+    config.customLenForHash = [hash_len](const jungle::HashKeyLenParams& p) -> size_t {
+        return hash_len;
+    };
     config.bloomFilterBitsPerUnit = 10;
     CHK_Z(jungle::DB::open(&db, filename, config));
 
@@ -3014,7 +3016,9 @@ int key_length_limit_for_hash_test(size_t hash_len) {
     jungle::DB* db;
 
     config.maxEntriesInLogFile = 1000;
-    config.keyLenLimitForHash = hash_len;
+    config.customLenForHash = [hash_len](const jungle::HashKeyLenParams& p) -> size_t {
+        return hash_len;
+    };
     config.bloomFilterBitsPerUnit = 10;
     config.minFileSizeToCompact = 65536;
     CHK_Z(jungle::DB::open(&db, filename, config));

--- a/tests/unit/memtable_test.cc
+++ b/tests/unit/memtable_test.cc
@@ -61,7 +61,7 @@ int memtable_key_itr_test() {
         sprintf(valbuf, "value%zu_%zu", ii, idx[ii]);
         SizedBuf key(keybuf);
         Record rec_out;
-        CHK_Z(mt.getRecordByKey(NOT_INITIALIZED, key, nullptr, rec_out, false, false));
+        CHK_Z(mt.getRecordByKey(NOT_INITIALIZED, key, rec_out, false, false));
         CHK_EQ(SizedBuf(valbuf), rec_out.kv.value);
     }
 
@@ -267,7 +267,9 @@ int memtable_nearest_search_test() {
 int memtable_prefix_search_test() {
     Status s;
     DBConfig config;
-    config.keyLenLimitForHash = 8;
+    config.customLenForHash = [](const HashKeyLenParams& params) -> size_t {
+        return 8;
+    };
     LogMgrOptions l_opt;
     l_opt.dbConfig = &config;
     LogMgr l_mgr(nullptr, l_opt);
@@ -304,7 +306,6 @@ int memtable_prefix_search_test() {
         };
         CHK_Z( mt.getRecordsByPrefix( NOT_INITIALIZED,
                                       SizedBuf(strlen(keybuf), keybuf),
-                                      nullptr,
                                       search_cb,
                                       false,
                                       false ) );
@@ -328,7 +329,6 @@ int memtable_prefix_search_test() {
         };
         CHK_Z( mt.getRecordsByPrefix( NOT_INITIALIZED,
                                       SizedBuf(strlen(keybuf), keybuf),
-                                      nullptr,
                                       search_cb,
                                       false,
                                       false ) );


### PR DESCRIPTION
* If the callback function is given, user can decide the length of
prefix of the key to calculate the hash value. If not given, the
hash will be calculated based on the entire key.

* The previous `keyLenLimitForHash` is deprecated.