### PR TITLE
Add a new option to stop delaying compaction on seq loading

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -139,6 +139,7 @@ public:
         , numExpectedUserThreads(8)
         , purgeDeletedDocImmediately(true)
         , fastIndexScan(false)
+        , seqLoadingDelayFactor(0)
     {
         tableSizeRatio.push_back(2.5);
         levelSizeRatio.push_back(10.0);
@@ -533,6 +534,14 @@ public:
      * instead of iteration.
      */
     bool fastIndexScan;
+
+    /**
+     * Compaction tasks will be delayed while keys are being
+     * loaded in sequential order. If this value is non-zero,
+     * compactions will be triggered if the file size of an L0 table
+     * is greater than the max table size multiplied by this value.
+     */
+    uint32_t seqLoadingDelayFactor;
 };
 
 class GlobalConfig {

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -107,7 +107,7 @@ void DBMgr::initInternal(const GlobalConfig& config) {
               config.compactorSleepDuration_ms);
     _log_info(myLog, "auto sync by flusher: %s, "
               "min number of records to flush: %zu",
-              config.flusherAutoSync ? "ON" : "OFF",
+              get_on_off_str(config.flusherAutoSync),
               config.flusherMinRecordsToTrigger);
 
     {

--- a/src/internal_helper.h
+++ b/src/internal_helper.h
@@ -466,25 +466,25 @@ inline int cmp_null_chk(void* a, void *b) {
     return 0xff;
 }
 
-inline size_t getMurmurHash32(const SizedBuf& data) {
+inline size_t get_murmur_hash_32(const SizedBuf& data) {
     uint32_t output = 0;
     MurmurHash3_x86_32(data.data, data.size, 0, &output);
     return output;
 }
 
-inline size_t getMurmurHash(const SizedBuf& data, size_t limit) {
+inline size_t get_murmur_hash(const SizedBuf& data, size_t limit) {
     uint32_t output = 0;
     MurmurHash3_x86_32(data.data, data.size, 0, &output);
     return output % limit;
 }
 
-inline uint64_t getMurmurHash64(const SizedBuf& data) {
+inline uint64_t get_murmur_hash_64(const SizedBuf& data) {
     uint64_t output[2];
     MurmurHash3_x64_128(data.data, data.size, 0, output);
     return output[0];
 }
 
-inline const char* getOnOffStr(bool cond) {
+inline const char* get_on_off_str(bool cond) {
     if (cond) return "ON";
     else return "OFF";
 }

--- a/src/log_mgr.cc
+++ b/src/log_mgr.cc
@@ -175,10 +175,10 @@ void LogMgr::logMgrSettings() {
 
     _log_info( myLog,
                "initialized log manager, memtable flush buffer %zu, "
-               "direct-IO %s, custom hash length %s",
+               "direct-IO %s, custom hash length function %s",
                g_conf->memTableFlushBufferSize,
-               ( opt.dbConfig->directIoOpt.enabled ? "ON" : "OFF" ),
-               ( opt.dbConfig->customLenForHash ? "ON" : "OFF" ) );
+               get_on_off_str(opt.dbConfig->directIoOpt.enabled),
+               get_on_off_str((bool)opt.dbConfig->customLenForHash) );
 }
 
 Status LogMgr::rollback(uint64_t seq_upto) {

--- a/src/table_file.cc
+++ b/src/table_file.cc
@@ -1106,7 +1106,7 @@ Status TableFile::get(DB* snap_handle,
         fdb_kvs_handle* kvs_db = g.handle->db;
 
         bool skip_normal_search = false;
-        uint32_t key_hash = getMurmurHash32(data_to_hash);
+        uint32_t key_hash = get_murmur_hash_32(data_to_hash);
         IF ( !meta_only && tlbByKey ) {
             // Search booster if exists.
             memset(&doc_by_offset, 0x0, sizeof(doc_by_offset));

--- a/src/table_manifest.cc
+++ b/src/table_manifest.cc
@@ -603,7 +603,7 @@ Status TableManifest::getTablesPoint(const size_t level,
         SizedBuf data_to_hash = get_data_to_hash(tableMgr->getDbConfig(), key, false);
         size_t num_partitions = tableMgr->getNumL0Partitions();
         size_t target_hash = num_partitions;
-        target_hash = getMurmurHash(data_to_hash, num_partitions);
+        target_hash = get_murmur_hash(data_to_hash, num_partitions);
         return getTablesByHash(l_info, target_hash, tables_out);
 
     } else {
@@ -779,7 +779,7 @@ Status TableManifest::getTablesPrefix(const size_t level,
         size_t num_partitions = tableMgr->getNumL0Partitions();
         size_t target_hash = num_partitions;
         if (used_custom_hash) {
-            target_hash = getMurmurHash(data_to_hash, num_partitions);
+            target_hash = get_murmur_hash(data_to_hash, num_partitions);
         }
         return getTablesByHash(l_info, target_hash, tables_out);
 

--- a/src/table_manifest.h
+++ b/src/table_manifest.h
@@ -96,7 +96,7 @@ struct TableInfo {
             _log_info(temp, "removed level %zu file %zu "
                       "ref count %zu -> %zu status %d mflag %s",
                       level, number, count, count-1, status.load(),
-                      (migration ? "ON" : "OFF") );
+                      get_on_off_str(migration) );
             if (count == 1) {
                 // NOTE: We should not remove file object if this
                 //       table is being migrated to next level, as

--- a/src/table_mgr.cc
+++ b/src/table_mgr.cc
@@ -57,7 +57,7 @@ TableMgr::~TableMgr() {
 
 uint32_t TableMgr::getKeyHash(const SizedBuf& key) const {
     SizedBuf data_to_hash = get_data_to_hash(opt.dbConfig, key, false);
-    return getMurmurHash32(data_to_hash);
+    return get_murmur_hash_32(data_to_hash);
 }
 
 Status TableMgr::createNewTableFile( size_t level,
@@ -98,8 +98,7 @@ void TableMgr::logTableSettings(const DBConfig* db_config) {
                    db_config->maxBlockReuseCycle,
                    db_config->purgeDeletedDocImmediately
                    ? "purge immediately" : "keep until compaction",
-                   db_config->fastIndexScan
-                   ? "ON" : "OFF",
+                   get_on_off_str(db_config->fastIndexScan),
                    db_config->throttlingNumLogFilesSoft,
                    db_config->throttlingNumLogFilesHard );
     } else {
@@ -115,7 +114,7 @@ void TableMgr::logTableSettings(const DBConfig* db_config) {
     _log_info( myLog, "table lookup booster limit %zu %zu",
                getBoosterLimit(0), getBoosterLimit(1) );
     _log_info( myLog, "next level extension %s",
-               getOnOffStr(db_config->nextLevelExtension) );
+               get_on_off_str(db_config->nextLevelExtension) );
     _log_info( myLog, "bloom filter bits per unit: %.1f",
                db_config->bloomFilterBitsPerUnit );
     if (db_config->nextLevelExtension) {
@@ -133,6 +132,8 @@ void TableMgr::logTableSettings(const DBConfig* db_config) {
             ratio_str += std::to_string(dd) + " ";
         }
         _log_info( myLog, "ratio: %s", ratio_str.c_str() );
+        _log_info( myLog, "sequential loading delay limit factor: %u",
+                   db_config->seqLoadingDelayFactor );
     }
 
     _log_info( myLog, "pre flush condition %zu sec, %zu bytes",

--- a/tests/bench/bench_config.h
+++ b/tests/bench/bench_config.h
@@ -74,11 +74,11 @@ struct BenchConfig {
 
         const auto& prefix = obj["prefix"];
         if (prefix.NotNull()) {
-            conf.prefixLens.reserve(prefix.size());
-            conf.prefixFanout.reserve(prefix.size());
+            conf.prefixLengths.reserve(prefix.size());
+            conf.prefixFanouts.reserve(prefix.size());
             for (auto& element: obj["prefix"].ArrayRange()) {
-                conf.prefixLens.push_back(load_dist_def_from_json(element["length"]));
-                conf.prefixFanout.push_back(element["fanout"].ToInt());
+                conf.prefixLengths.push_back(load_dist_def_from_json(element["length"]));
+                conf.prefixFanouts.push_back(element["fanout"].ToInt());
             }
         }
         if (obj["key"].NotNull()) {
@@ -166,8 +166,8 @@ struct BenchConfig {
     bool initialLoad;
     size_t initialLoadRate;
     InitialLoadOrder initialLoadOrder;
-    std::vector<DistDef> prefixLens;
-    std::vector<size_t> prefixFanout;
+    std::vector<DistDef> prefixLengths;
+    std::vector<size_t> prefixFanouts;
     DistDef keyLen;
     DistDef valueLen;
     std::vector<WorkerDef> workerDefs;

--- a/tests/bench/db_adapter_jungle.cc
+++ b/tests/bench/db_adapter_jungle.cc
@@ -174,6 +174,8 @@ int JungleAdapter::open(const std::string& db_file,
     _jint(table_size_mb, configObj, "l1_table_size_mb");
     config.maxL1TableSize = table_size_mb * 1024 * 1024;
 
+    _jint(config.seqLoadingDelayFactor, configObj, "seq_loading_delay_factor");
+
     bool direct_io = false;
     _jbool(direct_io, configObj, "direct_io");
     config.directIoOpt.enabled = direct_io;

--- a/tests/jungle/corruption_test.cc
+++ b/tests/jungle/corruption_test.cc
@@ -1150,7 +1150,7 @@ static int corrupted_table_manifest_test() {
         rec.kv = KV(k_str, v_str);
         rec.meta = m_str;
         rec.seqNum = NUM * 2;
-        uint32_t key_hash_val = getMurmurHash32(rec.kv.key);;
+        uint32_t key_hash_val = get_murmur_hash_32(rec.kv.key);;
         CHK_Z( t1->file->setSingle(key_hash_val, rec, offset_out, false, true) );
     }
 
@@ -1163,7 +1163,7 @@ static int corrupted_table_manifest_test() {
         rec.kv = KV(k_str, v_str);
         rec.meta = m_str;
         rec.seqNum = NUM * 2 + 1;
-        uint32_t key_hash_val = getMurmurHash32(rec.kv.key);
+        uint32_t key_hash_val = get_murmur_hash_32(rec.kv.key);
         CHK_Z( t1->file->setSingle(key_hash_val, rec, offset_out, false, true) );
     }
 
@@ -1176,7 +1176,7 @@ static int corrupted_table_manifest_test() {
         rec.kv = KV(k_str, v_str);
         rec.meta = m_str;
         rec.seqNum = NUM * 2 + 2;
-        uint32_t key_hash_val = getMurmurHash32(rec.kv.key);
+        uint32_t key_hash_val = get_murmur_hash_32(rec.kv.key);
         CHK_Z( t2->file->setSingle(key_hash_val, rec, offset_out, false, true) );
     }
 


### PR DESCRIPTION
* If user is loading keys sequentially (i.e., key order), Jungle
delays LO -> L1 compaction until it becomes random. However, it may
cause disk usage problem so that we need an ability to stop delaying
compaction.

* Added a new option for it: if L0 table size becomes bigger than
the given factor, L0 -> L1 compaction will be allowed even during the
sequential loading.

* L0 -> L1 compaction will also allowed when user requests a manual
compaction through debug parameter.