### PR TITLE
Tolerate empty DB for sampling

### DIFF
--- a/src/sampler.cc
+++ b/src/sampler.cc
@@ -21,7 +21,8 @@ Status Sampler::getSampleKeys(DB* db,
     uint64_t min_seq = 1, max_seq = 0;
     db->getMaxSeqNum(max_seq);
     if (min_seq > max_seq) {
-        return Status::INVALID_SEQNUM;
+        // NOTE: This happens when the DB is empty, we should return OK with empty list.
+        return Status::OK;
     }
 
     uint64_t num_remaining = params.numSamples;

--- a/tests/jungle/basic_op_test.cc
+++ b/tests/jungle/basic_op_test.cc
@@ -3094,6 +3094,12 @@ int sample_key_test() {
     config.maxEntriesInLogFile = 1000;
     CHK_Z(jungle::DB::open(&db, filename, config));
 
+    {   // Sampling on an empty DB should be fine.
+        std::list<jungle::SizedBuf> keys_out;
+        CHK_Z( db->getSampleKeys(jungle::SamplingParams(100), keys_out) );
+        CHK_Z( keys_out.size() );
+    }
+
     const size_t NUM = 10000;
 
     auto insert_keys = [&]() {


### PR DESCRIPTION
* Getting sample keys should not fail on an empty DB.