### PR TITLE
Fix to race between compaction threads

### DIFF
--- a/src/table_split.cc
+++ b/src/table_split.cc
@@ -389,7 +389,10 @@ Status TableMgr::mergeLevel(const CompactOptions& options,
     // Find the target table (i.e., right before the victim).
     std::list<TableInfo*> tables;
     SizedBuf empty_key;
-    mani->getTablesRange(level, empty_key, empty_key, tables);
+    {   // WARNING: See the comment at `mani->removeTableFile` in `compactLevelItr`.
+        std::lock_guard<std::mutex> l(mani->getLock());
+        mani->getTablesRange(level, empty_key, empty_key, tables);
+    }
 
     TableInfo* target_table = nullptr;
     for (TableInfo* tt: tables) {
@@ -535,7 +538,10 @@ Status TableMgr::fixTable(const CompactOptions& options,
     // Find the target table (i.e., right before the victim).
     std::list<TableInfo*> tables;
     SizedBuf empty_key;
-    mani->getTablesRange(level, empty_key, empty_key, tables);
+    {   // WARNING: See the comment at `mani->removeTableFile` in `compactLevelItr`.
+        std::lock_guard<std::mutex> l(mani->getLock());
+        mani->getTablesRange(level, empty_key, empty_key, tables);
+    }
 
     TableInfo* target_table = nullptr;
     for (TableInfo* tt: tables) {


### PR DESCRIPTION
* If a compaction thread is removing the table with the smallest key,
meanwhile the other compaction threads are going to write some keys
that are supposed to go to the smallest table, there is a race
condition which results in writing data to incorrect table. This
happens only when there are more than 3 levels and there are more than
2 compaction threads.

* All compaction threads who want to write data in the same level should
hold a lock when they get the list of table for the given range.

* It does not affect user threads, no performance impact.