### PR TITLE
Extend `DBStats` to return table hierarchy

### DIFF
--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -531,7 +531,8 @@ public:
      * @param[out] stats_out Stats as a result of this API call.
      * @return OK on success.
      */
-    Status getStats(DBStats& stats_out);
+    Status getStats(DBStats& stats_out,
+                    const DBStatsOptions& opt = DBStatsOptions());
 
     /**
      * Extract sample keys.

--- a/src/jungle.cc
+++ b/src/jungle.cc
@@ -832,7 +832,7 @@ Status DB::delRecord(const Record& rec) {
     return p->logMgr->setSN(rec_local);
 }
 
-Status DB::getStats(DBStats& stats_out) {
+Status DB::getStats(DBStats& stats_out, const DBStatsOptions& opt) {
     Status s;
     EP( p->checkHandleValidity() );
 
@@ -870,7 +870,12 @@ Status DB::getStats(DBStats& stats_out) {
     }
 
     TableStats t_stats;
-    if (p && p->tableMgr) p->tableMgr->getStats(t_stats);
+    if (p && p->tableMgr) {
+        p->tableMgr->getStats( t_stats,
+                               ( opt.getTableHierarchy
+                                 ? &stats_out.tableHierarchy
+                                 : nullptr ) );
+    }
     stats_out.numKvs = t_stats.numKvs + num_kvs_log;
     stats_out.workingSetSizeByte = t_stats.workingSetSizeByte;
     stats_out.numIndexNodes = t_stats.numIndexNodes;

--- a/src/table_mgr.cc
+++ b/src/table_mgr.cc
@@ -800,7 +800,8 @@ Status TableMgr::getAvailCheckpoints(std::list<uint64_t>& chk_out) {
     return Status();
 }
 
-Status TableMgr::getStats(TableStats& aggr_stats_out) {
+Status TableMgr::getStats(TableStats& aggr_stats_out,
+                          TableHierarchy* th_out) {
     Status s;
     aggr_stats_out.numKvs = 0;
 
@@ -824,6 +825,19 @@ Status TableMgr::getStats(TableStats& aggr_stats_out) {
 
         min_table_idx = std::min(cur_table->number, min_table_idx);
         max_table_idx = std::max(cur_table->number, max_table_idx);
+
+        if (th_out) {
+            TableHierarchyInfo thi;
+            thi.level = cur_table->level;
+            thi.tableIdx = cur_table->number;
+            if (thi.level == 0) {
+                thi.partitionIdx = cur_table->hashNum;
+            } else {
+                cur_table->minKey.copyTo(thi.minKey);
+            }
+
+            (*th_out)[thi.level].push_back( std::move(thi) );
+        }
 
         cur_table->done();
     }

--- a/src/table_mgr.h
+++ b/src/table_mgr.h
@@ -269,7 +269,8 @@ public:
         if (mani) mani->setLogger(myLog);
     }
 
-    Status getStats(TableStats& aggr_stats_out);
+    Status getStats(TableStats& aggr_stats_out,
+                    TableHierarchy* th_out = nullptr);
 
     Status getLastSeqnum(uint64_t& seqnum_out);
 


### PR DESCRIPTION
* Introduced a new option containing flag(s). If the flag is set,
`DBStats` will contain the detailed table hierarchy info.