### PR TITLE
Add an API for inter-process snapshot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ if (CODE_COVERAGE GREATER 0)
                      compaction_test
                      mt_test
                      log_reclaim_test
+                     custom_mani_verifier
                      level_extension_test
                      table_lookup_booster_test
                      compression_test

--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -542,6 +542,21 @@ public:
      * is greater than the max table size multiplied by this value.
      */
     uint32_t seqLoadingDelayFactor;
+
+    /**
+     * [EXPERIMENTAL]
+     * Only with read-only flag and log store mode.
+     * If given, Jungle will open the DB instance, but use the manifest
+     * files in the given path, instead of those in the original path.
+     *
+     * The main purpose of this is for opening a snapshot by separate
+     * processes. While a process is working on the DB, another process
+     * can open the same DB path in read-only mode, and sees the snapshot
+     * of it provided by the manifest files in the path.
+     *
+     * The custom manifest files should be created by `cloneManifest()` API.
+     */
+    std::string customManifestPath;
 };
 
 class GlobalConfig {

--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -133,6 +133,22 @@ public:
                         const uint64_t checkpoint = 0);
 
     /**
+     * [Experimental]
+     * Make a clone of manifest files, and write them in the given path.
+     * Other processes can open the current DB instance with the cloned
+     * manifest files, which works as a snapshot, while this process is
+     * still able to modify it.
+     *
+     * Currently support for log store mode only.
+     *
+     * @param target_path Output path where manifest files will be stored.
+     * @param snap_out Snapshot instance to avoid removing files.
+     * @return OK on success.
+     */
+    Status cloneManifest(const std::string& target_path,
+                         DB** snap_out);
+
+    /**
      * Rollback the given instance to the given sequence number.
      * Only supported in log section mode now.
      *

--- a/include/libjungle/status.h
+++ b/include/libjungle/status.h
@@ -90,6 +90,7 @@ public:
         INVALID_CONFIG                  = -63,
         DECOMPRESSION_FAILED            = -64,
         OPERATION_STOPPED               = -65,
+        MANIFEST_NOT_EXIST              = -66,
 
         ERROR                           = -32768
     };
@@ -171,8 +172,9 @@ public:
                 "UNKNOWN_LOG_FLAG",
                 "EMPTY_BATCH",
                 "INVALID_CONFIG",
-                "DECOMPRESSION_FAILED"
-                "OPERATION_STOPPED"
+                "DECOMPRESSION_FAILED",
+                "OPERATION_STOPPED",
+                "MANIFEST_NOT_EXIST"
                 } );
         uint32_t index = -val;
         if (index < names.size()) {

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -463,6 +463,15 @@ Status LogManifest::load(const std::string& path,
    }
 }
 
+Status LogManifest::clone(const std::string& dst_path) {
+    if (mFileName.empty() || !fOps) return Status::NOT_INITIALIZED;
+
+    std::unique_lock<std::mutex> l(mFileWriteLock);
+    std::string src_file = mFileName;
+    std::string dst_file = dst_path + "/" + logMgr->getManifestFilename();
+    return BackupRestore::copyFile(fOps, src_file, dst_file, true);
+}
+
 Status LogManifest::store(bool call_fsync) {
     if (mFileName.empty() || !fOps) return Status::NOT_INITIALIZED;
 

--- a/src/log_manifest.h
+++ b/src/log_manifest.h
@@ -229,6 +229,8 @@ public:
 
     Status store(bool call_fsync);
 
+    Status clone(const std::string& dst_path);
+
     static Status copyFile(FileOps* f_ops,
                            const std::string& src_file,
                            const std::string& dst_file);

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -125,6 +125,8 @@ public:
 
     ~LogMgr();
 
+    std::string getManifestFilename() const;
+
     Status init(const LogMgrOptions& lm_opt);
 
     void logMgrSettings();
@@ -139,6 +141,11 @@ public:
                         const uint64_t checkpoint,
                         std::list<LogFileInfo*>*& log_file_list_out);
     Status closeSnapshot(DB* snap_handle);
+
+    Status cloneManifest(DB* snap_handle,
+                         const uint64_t checkpoint,
+                         const std::string& dst_path,
+                         std::list<LogFileInfo*>*& log_file_list_out);
 
     void lockWriteMutex();
 

--- a/src/table_manifest.cc
+++ b/src/table_manifest.cc
@@ -270,9 +270,19 @@ Status TableManifest::load(const std::string& path,
     return s;
    }
 }
+Status TableManifest::clone(const std::string& dst_path) {
+    if (mFileName.empty() || !fOps) return Status::NOT_INITIALIZED;
+
+    std::unique_lock<std::mutex> l(mFileWriteLock);
+    std::string src_file = mFileName;
+    std::string dst_file = dst_path + "/" + tableMgr->getManifestFilename();
+    return BackupRestore::copyFile(fOps, src_file, dst_file, true);
+}
 
 Status TableManifest::store(bool call_fsync) {
     if (mFileName.empty() || !fOps) return Status::NOT_INITIALIZED;
+
+    std::unique_lock<std::mutex> lg(mFileWriteLock);
 
     Status s;
 

--- a/src/table_manifest.h
+++ b/src/table_manifest.h
@@ -178,6 +178,7 @@ public:
     Status load(const std::string& path,
                 const uint64_t prefix_num,
                 const std::string& filename);
+    Status clone(const std::string& dst_path);
     Status store(bool call_fsync);
     Status storeTableStack(RwSerializer& ss, TableInfo* base_table);
 
@@ -242,32 +243,59 @@ private:
     void pushTablesInStack(TableInfo* t_info,
                            std::list<TableInfo*>& tables_out);
 
-    // Backward pointer to table manager.
+    /**
+     * Backward pointer to table manager.
+     */
     const TableMgr* tableMgr;
 
-    // File operations.
+    /**
+     * File operations.
+     */
     FileOps* fOps;
 
-    // Manifest file handle.
+    /**
+     * Manifest file handle.
+     */
     FileHandle* mFile;
 
-    // Path.
+    /**
+     * DB path.
+     */
     std::string dirPath;
 
-    // Manifest file name.
+    /**
+     * Manifest file name.
+     */
     std::string mFileName;
 
-    // Total LSM levels.
+    /**
+     * Lock for level info.
+     */
     std::mutex levelsLock;
+
+    /**
+     * Level info.
+     */
     std::vector<LevelInfo*> levels;
 
-    // Current greatest table number.
+    /**
+     * Current greatest table number.
+     */
     std::atomic<uint64_t> maxTableNum;
 
-    // To guarantee atomic update of manifest.
+    /**
+     * To guarantee atomic update of manifest.
+     */
     std::mutex tableUpdateLock;
 
-    // Logger.
+    /**
+     * Only one thread is allowed to write the manifest file.
+     */
+    std::mutex mFileWriteLock;
+
+    /**
+     * Logger.
+     */
     SimpleLogger* myLog;
 };
 

--- a/src/table_mgr.h
+++ b/src/table_mgr.h
@@ -155,11 +155,18 @@ public:
         FIX = 0x6,
     };
 
+    std::string getManifestFilename() const;
+
     Status init(const TableMgrOptions& _options);
 
     Status removeStaleFiles();
 
     Status shutdown();
+
+    Status cloneManifest(DB* snap_handle,
+                         const uint64_t checkpoint,
+                         const std::string& dst_path,
+                         std::list<TableInfo*>*& table_list_out);
 
     Status openSnapshot(DB* snap_handle,
                         const uint64_t checkpoint,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -97,6 +97,11 @@ add_executable(log_reclaim_test ${LOG_RECLAIM_TEST})
 target_link_libraries(log_reclaim_test ${JUNGLE_TEST_DEPS})
 add_dependencies(log_reclaim_test static_lib)
 
+set(CUSTOM_MANI_VERIFIER ${TEST_DIR}/jungle/custom_mani_verifier.cc)
+add_executable(custom_mani_verifier ${CUSTOM_MANI_VERIFIER})
+target_link_libraries(custom_mani_verifier ${JUNGLE_TEST_DEPS})
+add_dependencies(custom_mani_verifier static_lib)
+
 set(COMPRESSION_TEST ${TEST_DIR}/jungle/compression_test.cc)
 add_executable(compression_test ${COMPRESSION_TEST})
 target_link_libraries(compression_test ${JUNGLE_TEST_DEPS})

--- a/tests/jungle/custom_mani_verifier.cc
+++ b/tests/jungle/custom_mani_verifier.cc
@@ -1,0 +1,69 @@
+/************************************************************************
+Copyright 2017-present eBay Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+**************************************************************************/
+
+#include "jungle_test_common.h"
+
+#include "internal_helper.h"
+#include "test_common.h"
+
+#include <fstream>
+#include <vector>
+
+#include <stdio.h>
+
+int main(int argc , char** argv) {
+    // format:
+    //   [0]                  [1]    [2]             [3]         [4]
+    //   custom_mani_verifier <path> <manifest path> <start idx> <end idx>
+
+    if (argc < 4) {
+        printf("too few arguments\n");
+        return -1;
+    }
+
+    std::string db_path = argv[1];
+    uint64_t start_idx = std::atol(argv[3]);
+    uint64_t end_idx = std::atol(argv[4]);
+
+    jungle::Status s;
+    jungle::DBConfig config;
+    config.logSectionOnly = true;
+    config.customManifestPath = argv[2];
+    config.readOnly = true;
+
+    jungle::DB* db;
+
+    CHK_Z( jungle::DB::open(&db, db_path, config) );
+
+    for (size_t ii = start_idx; ii <= end_idx; ++ii) {
+        jungle::KV kv_out;
+        jungle::KV::Holder h(kv_out);
+        CHK_Z( db->getSN(ii, kv_out) );
+
+        std::string key_str = "k" + TestSuite::lzStr(8, ii);
+        std::string val_str = "v" + TestSuite::lzStr(16, ii);
+        CHK_EQ(key_str, kv_out.key.toString());
+        CHK_EQ(val_str, kv_out.value.toString());
+    }
+
+    // Reading end_idx + 1 should fail.
+    jungle::KV kv_out;
+    CHK_NOT( db->getSN(end_idx + 1, kv_out) );
+
+    CHK_Z( jungle::DB::close(db) );
+
+    return 0;
+}


### PR DESCRIPTION
* Added `cloneManifest` API and `customManifestPath` config, to support
opening a snapshot by other processes.

* Currently only for log store mode.