### PR TITLE
fixed target path expression

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(EXAMPLES_DIR ${PROJECT_SOURCE_DIR}/examples)
 
 set(JUNGLE_TEST_DEPS
-    ${CMAKE_CURRENT_BINARY_DIR}/../libjungle.a
+    static_lib
     ${LIBSIMPLELOGGER}
     ${FDB_LIB_DIR}/libforestdb.a
     ${LIBSNAPPY}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@ set(JUNGLE_TEST_DIR ${TEST_DIR}/jungle)
 set(STRESS_TEST_DIR ${TEST_DIR}/stress)
 
 set(JUNGLE_TEST_DEPS
-    ${CMAKE_CURRENT_BINARY_DIR}/../libjungle.a
+    static_lib
     ${LIBSIMPLELOGGER}
     ${FDB_LIB_DIR}/libforestdb.a
     ${LIBSNAPPY}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(TOOLS_DIR ${PROJECT_SOURCE_DIR}/tools)
 
 set(JUNGLE_TOOLS_DEPS
-    ${CMAKE_CURRENT_BINARY_DIR}/../libjungle.a
+    static_lib
     ${LIBSIMPLELOGGER}
     ${FDB_LIB_DIR}/libforestdb.a
     ${LIBSNAPPY}


### PR DESCRIPTION
The right way to specify a path to a library built in a parent cmake is to just reference it by target name. This makes it resilient to overriding CMAKE_INSTALL_LIBDIR which is done in conan, for instance. 