### PR TITLE
Log iterator should not return records already flushed

### DIFF
--- a/src/log_file.cc
+++ b/src/log_file.cc
@@ -798,11 +798,12 @@ LogFile::Iterator::~Iterator() {}
 Status LogFile::Iterator::init(LogFile* l_file,
                                const SizedBuf& start_key,
                                const SizedBuf& end_key,
+                               const uint64_t seq_from,
                                const uint64_t seq_upto)
 {
     lFile = l_file;
     lFile->touch();
-    return mItr.init(lFile->mTable, start_key, end_key, seq_upto);
+    return mItr.init(lFile->mTable, start_key, end_key, seq_from, seq_upto);
 }
 
 Status LogFile::Iterator::initSN(LogFile* l_file,

--- a/src/log_file.h
+++ b/src/log_file.h
@@ -166,6 +166,7 @@ public:
         Status init(LogFile* l_file,
                     const SizedBuf& start_key,
                     const SizedBuf& end_key,
+                    const uint64_t seq_from,
                     const uint64_t seq_upto);
         Status initSN(LogFile* l_file,
                       const uint64_t min_seq,

--- a/src/log_iterator.cc
+++ b/src/log_iterator.cc
@@ -39,7 +39,7 @@ void LogMgr::Iterator::addLogFileItr(LogFileInfo* l_info, bool is_log_store_snap
     if (type == BY_SEQ) {
         l_itr->initSN(l_info->file, minSeqSnap, maxSeqSnap, is_log_store_snapshot);
     } else if (type == BY_KEY) {
-        l_itr->init(l_info->file, startKey, endKey, maxSeqSnap);
+        l_itr->init(l_info->file, startKey, endKey, minSeqSnap, maxSeqSnap);
     }
 
     ItrItem* ctx = new ItrItem();

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -132,6 +132,7 @@ public:
         Status init(const MemTable* m_table,
                     const SizedBuf& start_key,
                     const SizedBuf& end_key,
+                    const uint64_t seq_from,
                     const uint64_t seq_upto);
         Status initSN(const MemTable* m_table,
                       const uint64_t min_seq,
@@ -161,6 +162,11 @@ public:
         uint64_t maxSeq;
         SizedBuf startKey;
         SizedBuf endKey;
+
+        // (Key-iterator only) min allowed sequence number (inclusive).
+        uint64_t seqFrom;
+
+        // (Key-iterator only) max allowed sequence number (inclusive).
         uint64_t seqUpto;
     };
 
@@ -177,10 +183,11 @@ private:
         ~RecNode();
 
         static int cmp(skiplist_node *a, skiplist_node *b, void *aux);
-        Record* getLatestRecord(const uint64_t chk);
+        Record* getLatestRecord(const uint64_t seq_from, const uint64_t seq_upto);
         std::list<Record*> discardRecords(uint64_t seq_begin);
         uint64_t getMinSeq();
-        bool validKeyExist(const uint64_t chk,
+        bool validKeyExist(const uint64_t seq_from,
+                           const uint64_t seq_upto,
                            bool allow_tombstone = false);
 
         skiplist_node snode;

--- a/tests/jungle/key_itr_test.cc
+++ b/tests/jungle/key_itr_test.cc
@@ -175,7 +175,7 @@ int itr_key_purge() {
     CHK_Z(db->flushLogs(jungle::FlushOptions()));
 
     // Update even number KV pairs.
-    int seq_count = n;
+    int seq_count = n + 1;
     std::vector<jungle::KV> kv2(n);
     CHK_Z(_init_kv_pairs(n, kv2, "key", "value2_"));
     for (int ii=0; ii<n; ii+=2) {

--- a/tests/jungle/log_reclaim_test.cc
+++ b/tests/jungle/log_reclaim_test.cc
@@ -988,11 +988,19 @@ int immediate_log_purging_test() {
     CHK_Z( db->flushLogs(jungle::FlushOptions(), 1000) );
 
     // Scan all logs which will cause burst memtable load.
-    for (size_t ii=1001; ii<NUM; ++ii) {
-        jungle::KV kv_out;
-        jungle::KV::Holder h(kv_out);
-        CHK_Z( db->getSN(ii+1, kv_out) );
-        TestSuite::sleep_ms(1);
+    {
+        TestSuite::WorkloadGenerator wg(1000);
+        for (size_t ii=1001; ii<NUM; ++ii) {
+            jungle::KV kv_out;
+            jungle::KV::Holder h(kv_out);
+            CHK_Z( db->getSN(ii+1, kv_out) );
+
+            size_t todo = wg.getNumOpsToDo();
+            if (!todo) {
+                TestSuite::sleep_ms(1);
+            }
+            wg.addNumOpsDone(1);
+        }
     }
 
     jungle::DBStats stats;
@@ -1007,11 +1015,19 @@ int immediate_log_purging_test() {
     CHK_Z( jungle::DB::open(&db, filename, config) );
 
     // Do the same thing.
-    for (size_t ii=1001; ii<NUM; ++ii) {
-        jungle::KV kv_out;
-        jungle::KV::Holder h(kv_out);
-        CHK_Z( db->getSN(ii+1, kv_out) );
-        TestSuite::sleep_ms(1);
+    {
+        TestSuite::WorkloadGenerator wg(1000);
+        for (size_t ii=1001; ii<NUM; ++ii) {
+            jungle::KV kv_out;
+            jungle::KV::Holder h(kv_out);
+            CHK_Z( db->getSN(ii+1, kv_out) );
+
+            size_t todo = wg.getNumOpsToDo();
+            if (!todo) {
+                TestSuite::sleep_ms(1);
+            }
+            wg.addNumOpsDone(1);
+        }
     }
 
     db->getStats(stats);

--- a/tests/unit/memtable_test.cc
+++ b/tests/unit/memtable_test.cc
@@ -66,7 +66,7 @@ int memtable_key_itr_test() {
     }
 
     MemTable::Iterator m_itr;
-    CHK_Z(m_itr.init(&mt, SizedBuf(), SizedBuf(), NOT_INITIALIZED));
+    CHK_Z(m_itr.init(&mt, SizedBuf(), SizedBuf(), NOT_INITIALIZED, NOT_INITIALIZED));
 
     size_t count = 0;
 
@@ -132,7 +132,7 @@ int memtable_key_itr_chk_test() {
 
     MemTable::Iterator m_itr;
     // Iterator on snapshot upto 2.
-    CHK_Z(m_itr.init(&mt, SizedBuf(), SizedBuf(), 2));
+    CHK_Z(m_itr.init(&mt, SizedBuf(), SizedBuf(), NOT_INITIALIZED, 2));
 
     size_t count = 0;
 
@@ -372,7 +372,7 @@ int memtable_itr_seek_beyond_seq_test() {
 
     MemTable::Iterator m_itr;
     // Iterator on snapshot upto 500.
-    CHK_Z(m_itr.init(&mt, SizedBuf(), SizedBuf(), 500));
+    CHK_Z(m_itr.init(&mt, SizedBuf(), SizedBuf(), NOT_INITIALIZED, 500));
 
     // Goto end.
     m_itr.gotoEnd();


### PR DESCRIPTION
* Log iterator should not return records whose sequence number is smaller than the last flushed one. Otherwise, it may result in returning stale data, especially when the old data still resides in the log file while the flushed data is already compacted and removed from table file.