### PR TITLE
Fix to bug in `TableMgr::Iterator::gotoEnd()`

### DIFF
--- a/src/table_mgr.h
+++ b/src/table_mgr.h
@@ -423,6 +423,7 @@ public:
                             const uint64_t seqnum,
                             SeekOption opt,
                             bool goto_end = false);
+        Status moveToLastValid();
         inline int cmpSizedBuf(const SizedBuf& l, const SizedBuf& r);
         bool checkValidBySeq(ItrItem* item,
                              const uint64_t cur_seq,


### PR DESCRIPTION
* Same as in the other layer, table iterator should have `moveToLastValid()` function to find the last key with the first (i.e., the greatest/newest) sequence number. Otherwise, stale data may be returned if different tables have different versions of the same key.