### PR TITLE
CMake change for use as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if (LOGGER_NO_BACKTRACE GREATER 0)
     message(STATUS "---- NO BACKTRACE BY LOGGER ----")
 endif()
 
-file(COPY ${CMAKE_SOURCE_DIR}/scripts/runtests.sh
+file(COPY ${PROJECT_SOURCE_DIR}/scripts/runtests.sh
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # === CUSTOM LOGGER ===
@@ -194,6 +194,7 @@ set(JUNGLE_DEPS
     ${LIBDL})
 
 add_library(static_lib ${JUNGLE_CORE})
+target_include_directories(static_lib PUBLIC "${PROJECT_SOURCE_DIR}/include")
 target_link_libraries(static_lib ${JUNGLE_DEPS})
 set_target_properties(static_lib PROPERTIES OUTPUT_NAME jungle
                       CLEAN_DIRECT_OUTPUT 1)


### PR DESCRIPTION
Hi! Thank you for building this! It's cool!

I wanted to use Jungle as a submodule in my project but in order to get it to work I had to make some minor changes to the main CMakeLists.txt file.  

The problem is that when used as a submodule, `CMAKE_SOURCE_DIR` is no longer correct in Jungle cmake files.

This change allows me to use Jungle as a submodule like so:

```
cmake_minimum_required(VERSION 3.24)

project(storage_engines CXX)
execute_process(
  COMMAND ./prepare.sh -j8
  WORKING_DIRECTORY Jungle
)
add_subdirectory(Jungle)
add_executable(main main.cpp)
target_link_libraries(main static_lib)
```
Which I think is a nice way to use Jungle as a dependency.

