### PR TITLE
Support safe mode to return checksum error during iteration

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -17,6 +17,7 @@ limitations under the License.
 #pragma once
 
 #include "record.h"
+#include "status.h"
 
 #include <functional>
 #include <vector>
@@ -141,6 +142,7 @@ public:
         , purgeDeletedDocImmediately(true)
         , fastIndexScan(false)
         , seqLoadingDelayFactor(0)
+        , safeMode(false)
     {
         tableSizeRatio.push_back(2.5);
         levelSizeRatio.push_back(10.0);
@@ -565,6 +567,14 @@ public:
      * The custom manifest files should be created by `cloneManifest()` API.
      */
     std::string customManifestPath;
+
+    /**
+     * If DB files are corrupted, Jungle will try to avoid the process crash
+     * as much as possible.
+     * This mode will slow down operations, thus should not be used in
+     * real production environment.
+     */
+    bool safeMode;
 };
 
 class GlobalConfig {

--- a/src/db_internal.h
+++ b/src/db_internal.h
@@ -287,6 +287,9 @@ public:
     avl_tree curWindow;
     avl_node* windowCursor;
     Iterator* parent;
+
+    // Intolerable error detected. If set, we cannot proceed iteration.
+    Status fatalError;
 };
 
 struct GlobalBatchStatus {

--- a/src/table_file.cc
+++ b/src/table_file.cc
@@ -268,6 +268,17 @@ TableFile::~TableFile() {
     DELETE(tlbByKey);
 }
 
+Status TableFile::toJungleStatus(fdb_status fdb_s) {
+    switch (fdb_s) {
+    case FDB_RESULT_CHECKSUM_ERROR:
+        return Status::CHECKSUM_ERROR;
+    case FDB_RESULT_FILE_CORRUPTION:
+        return Status::FILE_CORRUPTION;
+    default:
+        return Status::ERROR;
+    }
+}
+
 std::string TableFile::getTableFileName(const std::string& path,
                                         uint64_t prefix_num,
                                         uint64_t table_file_num)
@@ -1146,7 +1157,12 @@ Status TableFile::get(DB* snap_handle,
         }
     }
     if (fs != FDB_RESULT_SUCCESS) {
-        return Status::KEY_NOT_FOUND;
+        if (fs == FDB_RESULT_KEY_NOT_FOUND) {
+            return Status::KEY_NOT_FOUND;
+        }
+        // Otherwise, error.
+        _log_err(myLog, "fdb_get failed: %d", fs);
+        return toJungleStatus(fs);
     }
 
    try {
@@ -1274,7 +1290,12 @@ Status TableFile::getNearest(DB* snap_handle,
         }
     }
     if (fs != FDB_RESULT_SUCCESS) {
-        return Status::KEY_NOT_FOUND;
+        if (fs == FDB_RESULT_KEY_NOT_FOUND) {
+            return Status::KEY_NOT_FOUND;
+        }
+        // Otherwise, error.
+        _log_err(myLog, "fdb_get failed: %d", fs);
+        return toJungleStatus(fs);
     }
 
    try {
@@ -1367,7 +1388,12 @@ Status TableFile::getPrefix(DB* snap_handle,
                              doc,
                              nearest_opt);
         if (fs != FDB_RESULT_SUCCESS) {
-            return Status::KEY_NOT_FOUND;
+            if (fs == FDB_RESULT_KEY_NOT_FOUND) {
+                return Status::KEY_NOT_FOUND;
+            }
+            // Otherwise, error.
+            _log_err(myLog, "fdb_get failed: %d", fs);
+            return toJungleStatus(fs);
         }
 
         // Find next greater key.

--- a/src/table_file.h
+++ b/src/table_file.h
@@ -86,6 +86,8 @@ public:
     static uint64_t getBfSizeByWss(const DBConfig* db_config,
                                    uint64_t wss);
 
+    static Status toJungleStatus(fdb_status fdb_s);
+
     FdbHandle* getIdleHandle();
 
     void returnHandle(FdbHandle* f_handle);
@@ -287,6 +289,8 @@ public:
         fdb_iterator* fdbItr;
         uint64_t minSeq;
         uint64_t maxSeq;
+
+        bool safeMode;
     };
 
     Status updateSnapshot();

--- a/src/table_iterator.cc
+++ b/src/table_iterator.cc
@@ -35,7 +35,7 @@ TableMgr::Iterator::~Iterator() {
     close();
 }
 
-void TableMgr::Iterator::addTableItr(DB* snap_handle, TableInfo* t_info) {
+Status TableMgr::Iterator::addTableItr(DB* snap_handle, TableInfo* t_info) {
     // Open iterator.
     TableFile::Iterator* t_itr = new TableFile::Iterator();
     if (type == BY_SEQ) {
@@ -47,6 +47,8 @@ void TableMgr::Iterator::addTableItr(DB* snap_handle, TableInfo* t_info) {
     ItrItem* ctx = new ItrItem();
     ctx->tInfo = t_info;
     ctx->tItr = t_itr;
+    tables[t_info->level].push_back(ctx);
+
     // If this iterator is out-of-range, `lastRec` will be empty.
     Status s = t_itr->get(ctx->lastRec);
     if (s) {
@@ -55,8 +57,11 @@ void TableMgr::Iterator::addTableItr(DB* snap_handle, TableInfo* t_info) {
                                  ? (ItrItem::cmpSeq)
                                  : (ItrItem::cmpKey);
         avl_insert(&curWindow, &ctx->an, cmp_func);
+    } else if (s == Status::CHECKSUM_ERROR || s == Status::FILE_CORRUPTION) {
+        // Intolerable error.
+        return s;
     }
-    tables[t_info->level].push_back(ctx);
+    return Status::OK;
 }
 
 Status TableMgr::Iterator::init(DB* snap_handle,
@@ -112,17 +117,28 @@ Status TableMgr::Iterator::initInternal(DB* snap_handle,
     endKey.alloc(end_key);
 
    try {
+    Status s;
     size_t n_levels = tMgr->mani->getNumLevels();
     tables.resize(n_levels);
 
     if (snap_handle) {
         // Snapshot
         assert(snap_handle->sn->tableList);
+        Status failed;
         for (auto& entry: *snap_handle->sn->tableList) {
             TableInfo* t_info = entry;
-            addTableItr(snap_handle, t_info);
+            // WARNING:
+            //   We should do `addTableItr` for all tables in `t_info_ret`,
+            //   to let them be closed during `close()` call.
+            s = addTableItr(snap_handle, t_info);
+            if (failed.ok() && !s.ok()) failed = s;
         }
         snapTableList = snap_handle->sn->tableList;
+
+        if (!failed.ok()) {
+            TC(failed);
+        }
+
     } else {
         // Normal
         for (size_t ii=0; ii<n_levels; ++ii) {
@@ -134,9 +150,18 @@ Status TableMgr::Iterator::initInternal(DB* snap_handle,
                 tMgr->mani->getTablesRange(ii, start_key, end_key, t_info_ret);
             }
 
+            Status failed;
             for (auto& entry: t_info_ret) {
                 TableInfo* t_info = entry;
-                addTableItr(snap_handle, t_info);
+                // WARNING:
+                //   We should do `addTableItr` for all tables in `t_info_ret`,
+                //   to let them be closed during `close()` call.
+                s = addTableItr(snap_handle, t_info);
+                if (failed.ok() && !s.ok()) failed = s;
+            }
+
+            if (!failed.ok()) {
+                TC(failed);
             }
         }
     }
@@ -146,13 +171,13 @@ Status TableMgr::Iterator::initInternal(DB* snap_handle,
     return Status();
 
    } catch (Status s) {
-    startKey.free();
-    endKey.free();
+    close();
     return s;
    }
 }
 
 Status TableMgr::Iterator::get(Record& rec_out) {
+    if (!fatalError.ok()) return fatalError;
     if (!windowCursor) return Status::KEY_NOT_FOUND;
 
     ItrItem* item = _get_entry(windowCursor, ItrItem, an);
@@ -161,6 +186,8 @@ Status TableMgr::Iterator::get(Record& rec_out) {
 }
 
 Status TableMgr::Iterator::prev() {
+    if (!fatalError.ok()) return fatalError;
+
     Status s;
 
     ItrItem* cur_item = _get_entry(windowCursor, ItrItem, an);
@@ -187,13 +214,23 @@ Status TableMgr::Iterator::prev() {
             item->flags = ItrItem::none;
             item->lastRec.free();
             s = item->tItr->get(item->lastRec);
-            assert(s);
 
             avl_cmp_func* cmp_func = (type == BY_SEQ)
                                      ? (ItrItem::cmpSeq)
                                      : (ItrItem::cmpKey);
             avl_insert(&curWindow, &item->an, cmp_func);
             cursor = avl_last(&curWindow);
+
+            if (s == Status::CHECKSUM_ERROR || s == Status::FILE_CORRUPTION) {
+                // Intolerable error.
+                fatalError = s;
+                cur_key.free();
+
+                // To make next `get()` call return error,
+                // return this function without error.
+                return Status();
+            }
+
         } else {
             item->flags |= ItrItem::no_more_prev;
             cursor = avl_prev(&item->an);
@@ -234,6 +271,8 @@ Status TableMgr::Iterator::prev() {
 }
 
 Status TableMgr::Iterator::next() {
+    if (!fatalError.ok()) return fatalError;
+
     Status s;
 
     ItrItem* cur_item = _get_entry(windowCursor, ItrItem, an);
@@ -260,13 +299,23 @@ Status TableMgr::Iterator::next() {
             item->flags = ItrItem::none;
             item->lastRec.free();
             s = item->tItr->get(item->lastRec);
-            assert(s);
 
             avl_cmp_func* cmp_func = (type == BY_SEQ)
                                      ? (ItrItem::cmpSeq)
                                      : (ItrItem::cmpKey);
             avl_insert(&curWindow, &item->an, cmp_func);
             cursor = avl_first(&curWindow);
+
+            if (s == Status::CHECKSUM_ERROR || s == Status::FILE_CORRUPTION) {
+                // Intolerable error.
+                fatalError = s;
+                cur_key.free();
+
+                // To make next `get()` call return error,
+                // return this function without error.
+                return Status();
+            }
+
         } else {
             item->flags |= ItrItem::no_more_next;
             cursor = avl_next(&item->an);

--- a/src/table_mgr.h
+++ b/src/table_mgr.h
@@ -411,7 +411,7 @@ public:
             Record lastRec;
         };
 
-        void addTableItr(DB* snap_handle, TableInfo* t_info);
+        Status addTableItr(DB* snap_handle, TableInfo* t_info);
         Status initInternal(DB* snap_handle,
                             TableMgr* table_mgr,
                             uint64_t min_seq,
@@ -442,6 +442,9 @@ public:
         SizedBuf endKey;
         avl_tree curWindow;
         avl_node* windowCursor;
+
+        // Intolerable error detected. If set, we cannot proceed iteration.
+        Status fatalError;
     };
 
 protected:


### PR DESCRIPTION
* Iterator most likely causes crash if files are corrupted.

* Added safe mode, to let iterator normally return checksum error code without crash. It can be used for DB file validation.