### PR TITLE
Add dedicated flusher for syncOnly

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -582,7 +582,7 @@ public:
     GlobalConfig()
         : globalLogPath("./")
         , numFlusherThreads(1)
-        , dedicatedFlusherForAsyncReqs(false)
+        , numDedicatedFlusherForAsyncReqs(0)
         , flusherSleepDuration_ms(500)
         , flusherMinRecordsToTrigger(65536)
         , flusherMinLogFilesToTrigger(16)
@@ -606,10 +606,10 @@ public:
     size_t numFlusherThreads;
 
     /**
-     * Create a dedicated flusher for async request. Only effective when
-     * `numFlusherThreads` >= 2.
+     * Create dedicated flushers for async request. Only effective when it is
+     * not 0 and `numFlusherThreads` > `numDedicatedFlusherForAsyncReqs`.
      */
-    bool dedicatedFlusherForAsyncReqs;
+    size_t numDedicatedFlusherForAsyncReqs;
 
     /**
      * Fluhser thread sleep time in ms.

--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -582,6 +582,7 @@ public:
     GlobalConfig()
         : globalLogPath("./")
         , numFlusherThreads(1)
+        , dedicatedSyncOnlyFlusher(false)
         , flusherSleepDuration_ms(500)
         , flusherMinRecordsToTrigger(65536)
         , flusherMinLogFilesToTrigger(16)
@@ -592,8 +593,7 @@ public:
         , fdbCacheSize(0)
         , numTableWriters(8)
         , memTableFlushBufferSize(32768)
-        , shutdownLogger(true)
-        {}
+        , shutdownLogger(true) {}
 
     /**
      * Path where Jungle's global log will be located.
@@ -604,6 +604,13 @@ public:
      * Max number of flusher threads.
      */
     size_t numFlusherThreads;
+
+    /**
+     * Create a dedicated flusher for log store sync when log store and
+     * normal data store are used. Only effective when
+     * `numFlusherThreads` >= 2.
+     */
+    bool dedicatedSyncOnlyFlusher;
 
     /**
      * Fluhser thread sleep time in ms.

--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -582,7 +582,7 @@ public:
     GlobalConfig()
         : globalLogPath("./")
         , numFlusherThreads(1)
-        , dedicatedSyncOnlyFlusher(false)
+        , dedicatedFlusherForAsyncReqs(false)
         , flusherSleepDuration_ms(500)
         , flusherMinRecordsToTrigger(65536)
         , flusherMinLogFilesToTrigger(16)
@@ -606,11 +606,10 @@ public:
     size_t numFlusherThreads;
 
     /**
-     * Create a dedicated flusher for log store sync when log store and
-     * normal data store are used. Only effective when
+     * Create a dedicated flusher for async request. Only effective when
      * `numFlusherThreads` >= 2.
      */
-    bool dedicatedSyncOnlyFlusher;
+    bool dedicatedFlusherForAsyncReqs;
 
     /**
      * Fluhser thread sleep time in ms.

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -89,8 +89,8 @@ void DBMgr::initInternal(const GlobalConfig& config) {
     for (size_t ii=0; ii<config.numFlusherThreads; ++ii) {
         std::string t_name = "flusher_" + std::to_string(ii);
         Flusher* flusher = new Flusher(t_name, config);
-        if (gConfig.dedicatedSyncOnlyFlusher && ii > 0) {
-            flusher->handleSyncOnly = false;
+        if (gConfig.dedicatedFlusherForAsyncReqs && ii > 0) {
+            flusher->handleAsyncReqs = false;
         }
         wMgr->addWorker(flusher);
         flusher->run();

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -89,6 +89,9 @@ void DBMgr::initInternal(const GlobalConfig& config) {
     for (size_t ii=0; ii<config.numFlusherThreads; ++ii) {
         std::string t_name = "flusher_" + std::to_string(ii);
         Flusher* flusher = new Flusher(t_name, config);
+        if (gConfig.dedicatedSyncOnlyFlusher && ii > 0) {
+            flusher->handleSyncOnly = false;
+        }
         wMgr->addWorker(flusher);
         flusher->run();
     }

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -88,8 +88,8 @@ void DBMgr::initInternal(const GlobalConfig& config) {
     printGlobalConfig();
 
     bool dedicated_async_flusher =
-        gConfig.numDedicatedFlusherForAsyncReqs
-        && gConfig.numFlusherThreads > gConfig.numDedicatedFlusherForAsyncReqs;
+        config.numDedicatedFlusherForAsyncReqs
+        && config.numFlusherThreads > config.numDedicatedFlusherForAsyncReqs;
     for (size_t ii=0; ii<config.numFlusherThreads; ++ii) {
         std::string t_name = "flusher_" + std::to_string(ii);
         Flusher* flusher = new Flusher(t_name, config);

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -21,8 +21,9 @@ limitations under the License.
 #include "db_internal.h"
 #include "flusher.h"
 #include "internal_helper.h"
-#include "libjungle/db_config.h"
 #include "log_reclaimer.h"
+
+#include "libjungle/db_config.h"
 
 #include <set>
 

--- a/src/flusher.cc
+++ b/src/flusher.cc
@@ -87,7 +87,7 @@ Flusher::Flusher(const std::string& _w_name,
 {
     workerName = _w_name;
     gConfig = _config;
-    handleSyncOnly = true;
+    handleAsyncReqs = true;
     FlusherOptions options;
     options.sleepDuration_ms = gConfig.flusherSleepDuration_ms;
     options.worker = this;
@@ -108,7 +108,7 @@ void Flusher::work(WorkerOptions* opt_base) {
 
     // assuming the flusherQueue is only used for log store
     FlusherQueueElem* elem = nullptr;
-    if (handleSyncOnly) {
+    if (handleAsyncReqs) {
         elem = dbm->flusherQueue()->pop();
     }
 

--- a/src/flusher.cc
+++ b/src/flusher.cc
@@ -87,6 +87,7 @@ Flusher::Flusher(const std::string& _w_name,
 {
     workerName = _w_name;
     gConfig = _config;
+    handleSyncOnly = true;
     FlusherOptions options;
     options.sleepDuration_ms = gConfig.flusherSleepDuration_ms;
     options.worker = this;
@@ -105,7 +106,12 @@ void Flusher::work(WorkerOptions* opt_base) {
 
     DB* target_db = nullptr;
 
-    FlusherQueueElem* elem = dbm->flusherQueue()->pop();
+    // assuming the flusherQueue is only used for log store
+    FlusherQueueElem* elem = nullptr;
+    if (handleSyncOnly) {
+        elem = dbm->flusherQueue()->pop();
+    }
+
     if (elem) {
         // User assigned work check if it is already closed.
         std::lock_guard<std::mutex> l(dbm->dbMapLock);

--- a/src/flusher.cc
+++ b/src/flusher.cc
@@ -106,7 +106,6 @@ void Flusher::work(WorkerOptions* opt_base) {
 
     DB* target_db = nullptr;
 
-    // assuming the flusherQueue is only used for log store
     FlusherQueueElem* elem = nullptr;
     if (handleAsyncReqs) {
         elem = dbm->flusherQueue()->pop();

--- a/src/flusher.h
+++ b/src/flusher.h
@@ -16,6 +16,7 @@ limitations under the License.
 
 #pragma once
 
+#include "internal_helper.h"
 #include "worker_mgr.h"
 
 #include <libjungle/jungle.h>
@@ -82,6 +83,7 @@ public:
 
     GlobalConfig gConfig;
     size_t lastCheckedFileIndex;
+    bool handleSyncOnly;
 };
 
 

--- a/src/flusher.h
+++ b/src/flusher.h
@@ -83,7 +83,7 @@ public:
 
     GlobalConfig gConfig;
     size_t lastCheckedFileIndex;
-    bool handleSyncOnly;
+    bool handleAsyncReqs;
 };
 
 


### PR DESCRIPTION
This PR is based on the assumption that the async flusher queue is only used for log store. 