### PR TITLE
Fix to bug of invoking dedicated thread

### DIFF
--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -89,16 +89,20 @@ void DBMgr::initInternal(const GlobalConfig& config) {
     printGlobalConfig();
 
     bool dedicated_async_flusher =
-        config.numDedicatedFlusherForAsyncReqs
-        && config.numFlusherThreads > config.numDedicatedFlusherForAsyncReqs;
+        config.numDedicatedFlusherForAsyncReqs &&
+        config.numFlusherThreads > config.numDedicatedFlusherForAsyncReqs;
+
     for (size_t ii=0; ii<config.numFlusherThreads; ++ii) {
-        std::string t_name = "flusher_" + std::to_string(ii);
-        Flusher* flusher = new Flusher(t_name, config);
         // If dedicated flusher is enabled, only the first
         // `numDedicatedFlusherForAsyncReqs` flushers will handle async reqs.
-        if (dedicated_async_flusher && ii >= config.numDedicatedFlusherForAsyncReqs) {
-            flusher->handleAsyncReqs = false;
-        }
+        bool handle_async_reqs =
+            !(dedicated_async_flusher && ii >= config.numDedicatedFlusherForAsyncReqs);
+        std::string t_name =
+            handle_async_reqs
+            ? "flusher_ded_" + std::to_string(ii)
+            : "flusher_" + std::to_string(ii);
+        Flusher* flusher = new Flusher(t_name, config);
+        flusher->handleAsyncReqs = handle_async_reqs;
         wMgr->addWorker(flusher);
         flusher->run();
     }


### PR DESCRIPTION
* Since workers are inserted into `unordered_map`, there is no guarantee that the first invoked worker is the dedicated one. We should have separate worker name to distinguish the dedicated ones.