### PR TITLE
Reduce system call

### DIFF
--- a/src/internal_helper.cc
+++ b/src/internal_helper.cc
@@ -367,41 +367,41 @@ Status BackupRestore::backup(FileOps* f_ops,
     Status s;
     std::string dst_file = filename + ".bak";
 
-    try {
-        if (!f_ops->exist(dst_file)) {
-            if (*file) {
-                f_ops->close(*file);
-                delete *file;
-                *file = nullptr;
-            }
-        }
-
-        if (!(*file)) {
-            TC( f_ops->open(file, dst_file) );
-        }
-
-        size_t file_size = f_ops->eof(*file);
-        if (length > bytes_to_skip) {
-            TC( f_ops->pwrite( *file,
-                            ctx.data + bytes_to_skip,
-                            length - bytes_to_skip,
-                            bytes_to_skip ) );
-        }
-        if (file_size > length) {
-            f_ops->ftruncate(*file, length);
-        }
-
-        if (call_fsync) {
-            f_ops->fsync(*file);
-        }
-        return s;
-   } catch (Status s) {
+   try {
+    if (!f_ops->exist(dst_file)) {
         if (*file) {
             f_ops->close(*file);
             delete *file;
             *file = nullptr;
         }
-        return s;
+    }
+
+    if (!(*file)) {
+        TC( f_ops->open(file, dst_file) );
+    }
+
+    size_t file_size = f_ops->eof(*file);
+    if (length > bytes_to_skip) {
+        TC( f_ops->pwrite( *file,
+                        ctx.data + bytes_to_skip,
+                        length - bytes_to_skip,
+                        bytes_to_skip ) );
+    }
+    if (file_size > length) {
+        f_ops->ftruncate(*file, length);
+    }
+
+    if (call_fsync) {
+        f_ops->fsync(*file);
+    }
+    return s;
+   } catch (Status s) {
+    if (*file) {
+        f_ops->close(*file);
+        delete *file;
+        *file = nullptr;
+    }
+    return s;
    }
 }
 

--- a/src/internal_helper.h
+++ b/src/internal_helper.h
@@ -131,6 +131,13 @@ public:
                          size_t length,
                          size_t bytes_to_skip,
                          bool call_fsync);
+    static Status backup(FileOps* f_ops,
+                         FileHandle** file,
+                         const std::string& filename,
+                         const SizedBuf& ctx,
+                         size_t length,
+                         size_t bytes_to_skip,
+                         bool call_fsync);
     static Status restore(FileOps* f_ops,
                           const std::string& filename);
 };

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -153,6 +153,7 @@ LogManifest::LogManifest(LogMgr* log_mgr, FileOps* _f_ops, FileOps* _f_l_ops)
     : fOps(_f_ops)
     , fLogOps(_f_l_ops)
     , mFile(nullptr)
+    , mBackupFile(nullptr)
     , lastFlushedLog(NOT_INITIALIZED)
     , lastSyncedLog(NOT_INITIALIZED)
     , maxLogFileNum(NOT_INITIALIZED)
@@ -173,6 +174,10 @@ LogManifest::~LogManifest() {
 
     if (mFile) {
         delete mFile;
+    }
+
+    if (mBackupFile) {
+        delete mBackupFile;
     }
     // NOTE: Skip `logFilesBySeq` as they share the actual memory.
     skiplist_node* cursor = skiplist_begin(&logFiles);
@@ -558,6 +563,7 @@ Status LogManifest::storeInternal(bool call_fsync) {
     // We will skip the common data and write different part only,
     // to reduce disk IOs (assuming that memory comparison is faster than disk write).
     uint32_t first_diff_pos = 0;
+    bool need_truncate = !lenCachedManifest || lenCachedManifest > ss.pos();
 
     if (lenCachedManifest) {
         uint32_t min_len = std::min(cachedManifest.size, (uint32_t)ss.pos());
@@ -591,8 +597,10 @@ Status LogManifest::storeInternal(bool call_fsync) {
     lenCachedManifest = ss.pos();
 
     // Should truncate tail.
-    fOps->ftruncate(mFile, ss.pos());
-
+    if (need_truncate) {
+        fOps->ftruncate(mFile, ss.pos());
+    }
+    
     bool backup_done = false;
     if (call_fsync) {
         s = fOps->fsync(mFile);
@@ -607,7 +615,7 @@ Status LogManifest::storeInternal(bool call_fsync) {
             // using the latest data.
             // Same as above, tolerate backup failure.
             Status s_backup = BackupRestore::backup
-                              ( fOps, mFileName, mani_buf,
+                              ( fOps, &mBackupFile, mFileName, mani_buf,
                                 ss.pos(),
                                 fullBackupRequired ? 0 : first_diff_pos,
                                 call_fsync );

--- a/src/log_manifest.h
+++ b/src/log_manifest.h
@@ -338,6 +338,7 @@ private:
     FileOps* fOps;
     FileOps* fLogOps;
     FileHandle* mFile;
+    FileHandle* mBackupFile;
     std::string dirPath;
     std::string mFileName;
     uint64_t prefixNum;


### PR DESCRIPTION
1. for log manifest, remove truncate if the previous size is smaller.
2. for backup log manifest, not open and close file in each call.