### PR TITLE
Add a new option `serializeMultiThreadedLogFlush`

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -143,6 +143,7 @@ public:
         , fastIndexScan(false)
         , seqLoadingDelayFactor(0)
         , safeMode(false)
+        , serializeMultiThreadedLogFlush(false)
     {
         tableSizeRatio.push_back(2.5);
         levelSizeRatio.push_back(10.0);
@@ -575,6 +576,14 @@ public:
      * real production environment.
      */
     bool safeMode;
+
+    /**
+     * If `true`, `sync` and `flushLogs` calls by multiple threads will be serialized,
+     * and executed one by one.
+     * If `false`, only one thread will execute `sync` and `flushLogs` calls, while
+     * the other concurrent threads will get `OPERATION_IN_PROGRESS` status.
+     */
+    bool serializeMultiThreadedLogFlush;
 };
 
 class GlobalConfig {

--- a/include/libjungle/params.h
+++ b/include/libjungle/params.h
@@ -205,6 +205,7 @@ struct DebugParams {
         , newLogBatchCb(nullptr)
         , getLogFileInfoBySeqCb(nullptr)
         , logFlushCb(nullptr)
+        , syncCb(nullptr)
         , forceMerge(false)
         {}
 
@@ -298,6 +299,12 @@ struct DebugParams {
      * before updating last synced sequence number of each log file.
      */
     std::function< void(const GenericCbParams&) > logFlushCb;
+
+    /**
+     * Callback function that will be invoked at the beginning log sync
+     * (reading memtable data and writing them into log files).
+     */
+    std::function< void(const GenericCbParams&) > syncCb;
 
     /**
      * If true, merge will proceed the task even with the small number

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -87,30 +87,44 @@ struct OpSema {
     OpSema() : enabled(true), grabbed(false) {}
     std::atomic<bool> enabled;
     std::atomic<bool> grabbed;
+
+    // Used only when `synchronizeMultiThreadedLogFlush` is on.
+    std::mutex lock;
 };
 
 struct OpSemaWrapper {
-    OpSemaWrapper(OpSema* _op_sema) : op_sema(_op_sema), acquired(false) {}
+    OpSemaWrapper(OpSema* op_sema, bool lock_mode = false)
+        : opSema(op_sema), acquired(false), lockMode(lock_mode) {}
     ~OpSemaWrapper() {
         if (acquired) {
-            op_sema->grabbed = false;
+            opSema->grabbed = false;
+            if (lockMode) {
+                opSema->lock.unlock();
+            }
         }
-        op_sema = nullptr;
+        opSema = nullptr;
         acquired = false;
     }
 
     bool acquire() {
-        bool expected = false;
-        bool val = true;
-        if ( op_sema->enabled &&
-             op_sema->grabbed.compare_exchange_weak(expected, val) ) {
+        if (lockMode) {
+            opSema->lock.lock();
+            opSema->grabbed = true;
             acquired = true;
+        } else {
+            bool expected = false;
+            bool val = true;
+            if ( opSema->enabled &&
+                 opSema->grabbed.compare_exchange_weak(expected, val) ) {
+                acquired = true;
+            }
         }
         return acquired;
     }
 
-    OpSema* op_sema;
+    OpSema* opSema;
     bool acquired;
+    bool lockMode;
 };
 
 namespace checker { class Checker; }


### PR DESCRIPTION
* With this option, and if multi threads are calling `sync` or `flushLogs`, all threads will be executed one by one instead of letting one thread be executed and returning `OPERATION_IN_PROGRESS` to the others.