### PR TITLE
Add a new option `skipManifestSync`

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -145,6 +145,7 @@ public:
         , seqLoadingDelayFactor(0)
         , safeMode(false)
         , serializeMultiThreadedLogFlush(false)
+        , skipManifestSync(false)
     {
         tableSizeRatio.push_back(2.5);
         levelSizeRatio.push_back(10.0);
@@ -595,6 +596,17 @@ public:
      * the other concurrent threads will get `OPERATION_IN_PROGRESS` status.
      */
     bool serializeMultiThreadedLogFlush;
+
+    /**
+     * [EXPERIMENTAL]
+     * If `true`, when `sync()` is invoked, only the actual log files will be synced,
+     * not the manifest file. The manifest file is synced when 1) a new log file is
+     * added, or 2) the DB is closed.
+     *
+     * Even without syncing the manifest file, Jungle can recover the last synced
+     * data by scanning the log files.
+     */
+    bool skipManifestSync;
 };
 
 class GlobalConfig {

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -459,6 +459,11 @@ protected:
     std::atomic<uint32_t> numMemtables;
 
     /**
+     * If `true`, the sync of manifest is a must in the next `sync()` call.
+     */
+    std::atomic<bool> needSkippedManiSync;
+
+    /**
      * Logger.
      */
     SimpleLogger* myLog;

--- a/tests/jungle/log_reclaim_test.cc
+++ b/tests/jungle/log_reclaim_test.cc
@@ -1660,6 +1660,69 @@ int dedicated_flusher_test() {
     return 0;
 }
 
+int sync_wo_manifest_test() {
+    std::string filename;
+    TEST_SUITE_PREPARE_PATH(filename);
+
+    jungle::Status s;
+    jungle::DBConfig config;
+    TEST_CUSTOM_DB_CONFIG(config);
+    jungle::DB* db = nullptr;
+
+    jungle::GlobalConfig g_config;
+    g_config.numFlusherThreads = 1;
+    jungle::init(g_config);
+
+    config.maxEntriesInLogFile = 10;
+    config.skipManifestSync = true;
+    CHK_Z(jungle::DB::open(&db, filename, config));
+
+    auto insert_keys = [&](size_t from, size_t to) {
+        for (size_t ii = from; ii < to; ++ii) {
+            std::string key_str = "key" + TestSuite::lzStr(5, ii);
+            std::string val_str = "val" + TestSuite::lzStr(5, ii);
+            CHK_Z( db->set( jungle::KV(key_str, val_str) ) );
+        }
+        return 0;
+    };
+    auto verify = [&](size_t upto) {
+        for (size_t ii = 0; ii < upto; ++ii) {
+            TestSuite::setInfo("ii=%zu", ii);
+            jungle::SizedBuf value_out;
+            jungle::SizedBuf::Holder h(value_out);
+            std::string key_str = "key" + TestSuite::lzStr(5, ii);
+            std::string val_str = "val" + TestSuite::lzStr(5, ii);
+            CHK_Z( db->get(jungle::SizedBuf(key_str), value_out) );
+            CHK_EQ(val_str, value_out.toString());
+        }
+        return 0;
+    };
+
+    CHK_Z(insert_keys(0, 11));
+    CHK_Z(db->sync(true));
+
+    CHK_Z(insert_keys(11, 15));
+    CHK_Z(db->sync(true));
+
+    // Copy file at this moment to mimic crash.
+    std::string clone_path = filename + "_clone";
+    TestSuite::copyfile(filename, clone_path);
+
+    CHK_Z(jungle::DB::close(db));
+
+    // Open clone.
+    // Even with crash without manifest sync, all 15 logs should be there.
+    CHK_Z(jungle::DB::open(&db, clone_path, config));
+    CHK_Z(verify(15));
+    CHK_Z(jungle::DB::close(db));
+
+    CHK_Z(jungle::shutdown());
+
+    TEST_SUITE_CLEANUP_PATH();
+    return 0;
+}
+
+
 } using namespace log_reclaim_test;
 
 int main(int argc, char** argv) {
@@ -1742,6 +1805,9 @@ int main(int argc, char** argv) {
 
     ts.doTest("dedicated flusher test",
               dedicated_flusher_test);
+
+    ts.doTest("sync without manifest test",
+              sync_wo_manifest_test);
 
 #if 0
     ts.doTest("reload empty files test",


### PR DESCRIPTION
* Syncing manifest file (and creating backup file) for every `sync()` call is too expensive. We can guarantee the durability of data even without manifest sync.

* If this option is `true`, manifest file (and its backup file) will be synced only when it is needed for durability.