### PR TITLE
Fix to potential data inconsistency bug

### DIFF
--- a/src/log_file.cc
+++ b/src/log_file.cc
@@ -401,7 +401,7 @@ Status LogFile::getPrefix(const uint64_t chk,
     return Status();
 }
 
-Status LogFile::flushMemTable(uint64_t upto) {
+Status LogFile::flushMemTable(uint64_t upto, uint64_t& flushed_seq_out) {
    touch();
    // Skip unnecessary flushing
    if (immutable && !fHandle && isSynced()) {
@@ -509,7 +509,7 @@ Status LogFile::flushMemTable(uint64_t upto) {
 
     RwSerializer rws(fOps, fHandle, true);
 
-    TC( mTable->flush(rws, upto) );
+    TC( mTable->flush(rws, upto, flushed_seq_out) );
     TC( mTable->appendFlushMarker(rws) );
 
     TC( fOps->flush(fHandle) );

--- a/src/log_file.h
+++ b/src/log_file.h
@@ -93,7 +93,7 @@ public:
                      bool allow_flushed_log,
                      bool allow_tombstone);
 
-    Status flushMemTable(uint64_t upto = NOT_INITIALIZED);
+    Status flushMemTable(uint64_t upto, uint64_t& flushed_seq_out);
 
     Status purgeMemTable();
 

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -1233,7 +1233,7 @@ Status MemTable::findOffsetOfSeq(SimpleLogger* logger,
 }
 
 // MemTable flush: skiplist (memory) -> log file. (disk)
-Status MemTable::flush(RwSerializer& rws, uint64_t upto)
+Status MemTable::flush(RwSerializer& rws, uint64_t upto, uint64_t& flushed_seq_out)
 {
     if (minSeqNum == NOT_INITIALIZED) {
         // No log in this file. Just do nothing and return OK.
@@ -1450,7 +1450,7 @@ Status MemTable::flush(RwSerializer& rws, uint64_t upto)
                skiplist_get_size(idxBySeq),
                start_seqnum, seqnum_upto);
 
-    syncedSeqNum = seqnum_upto;
+    flushed_seq_out = seqnum_upto;
     return Status();
 
    } catch (Status s) {

--- a/src/memtable.h
+++ b/src/memtable.h
@@ -97,7 +97,7 @@ public:
                                   uint64_t& offset_out,
                                   uint64_t* padding_start_pos_out = nullptr);
 
-    Status flush(RwSerializer& rws, uint64_t upto = NOT_INITIALIZED);
+    Status flush(RwSerializer& rws, uint64_t upto, uint64_t& flushed_seq_out);
     Status checkpoint(uint64_t& seq_num_out);
     Status getLogsToFlush(const uint64_t seq_num,
                           std::list<Record*>& list_out,


### PR DESCRIPTION
* During `LogMgr::sync`, if individual file's flush fails, we should not update `syncedSeqNum` of that file. Otherwise, there can be a risk that the manifest might write that incorrect number in another call stack, and that results in data inconsistency.