### PR TITLE
Fix to bug of sync log file inversion

### DIFF
--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -371,12 +371,28 @@ public:
     Status getLastFlushedSeqNum(uint64_t& seq_num_out);
 
     /**
+     * Get the last flushed log file number.
+     *
+     * @param[out] log_file_num_out Reference to log file number as a result.
+     * @return OK on success.
+     */
+    Status getLastFlushedLogFileNum(uint64_t& log_file_num_out);
+
+    /**
      * Get the last synced (written to file) sequence number.
      *
      * @param[out] seq_num_out Reference to sequence number as a result.
      * @return OK on success.
      */
     Status getLastSyncedSeqNum(uint64_t& seq_num_out);
+
+    /**
+     * Get the last synced (written to file) log file number.
+     *
+     * @param[out] log_file_num_out Reference to log file number as a result.
+     * @return OK on success.
+     */
+    Status getLastSyncedLogFileNum(uint64_t& log_file_num_out);
 
     /**
      * Get the list of checkpoint markers.

--- a/src/jungle.cc
+++ b/src/jungle.cc
@@ -397,10 +397,22 @@ Status DB::getLastFlushedSeqNum(uint64_t& seq_num_out) {
     return p->logMgr->getLastFlushedSeqNum(seq_num_out);
 }
 
+Status DB::getLastFlushedLogFileNum(uint64_t& log_file_num_out) {
+    Status s;
+    EP( p->checkHandleValidity() );
+    return p->logMgr->getLastFlushedLogFileNum(log_file_num_out);
+}
+
 Status DB::getLastSyncedSeqNum(uint64_t& seq_num_out) {
     Status s;
     EP( p->checkHandleValidity() );
     return p->logMgr->getLastSyncedSeqNum(seq_num_out);
+}
+
+Status DB::getLastSyncedLogFileNum(uint64_t& log_file_num_out) {
+    Status s;
+    EP( p->checkHandleValidity() );
+    return p->logMgr->getLastSyncedLogFileNum(log_file_num_out);
 }
 
 Status DB::getCheckpoints(std::list<uint64_t>& chk_out) {

--- a/src/log_mgr.h
+++ b/src/log_mgr.h
@@ -245,6 +245,9 @@ public:
     Status getLastFlushedSeqNum(uint64_t& seq_num_out);
     Status getLastSyncedSeqNum(uint64_t& seq_num_out);
 
+    Status getLastFlushedLogFileNum(uint64_t& log_file_num_out);
+    Status getLastSyncedLogFileNum(uint64_t& log_file_num_out);
+
     bool checkTimeToFlush(const GlobalConfig& config);
     Status close();
 


### PR DESCRIPTION
* If flush happens with `beyondLastSync=true` and `numFilesLimit`, if may overwrite last synced log file number with smaller number, that may result in sync order inversion.