### PR TITLE
Suppress verbose log during table iterator get

### DIFF
--- a/src/table_file.h
+++ b/src/table_file.h
@@ -291,6 +291,7 @@ public:
         uint64_t maxSeq;
 
         bool safeMode;
+        bool prevNextHappened;
     };
 
     Status updateSnapshot();


### PR DESCRIPTION
* If no record exists in the iterator range, the very first get may return failure, and that is expected. We should not leave an error log for that case, as it may be very verbose.