### PR TITLE
Introduce global throttling based on the number of log files

### DIFF
--- a/include/libjungle/db_config.h
+++ b/include/libjungle/db_config.h
@@ -789,6 +789,53 @@ public:
     CompactionThrottlingOptions ctOpt;
 
     /**
+     * Settings for Log Throttling. When there is heavy incoming traffic
+     * and the flush speed cannot keep up with the incoming write speed,
+     * the number of log files increases. If the total number of log files
+     * across all open database instances exceeds `startNumLogs`, user threads
+     * calling the write API will be temporarily blocked for a certain period
+     * of time.
+     *
+     * Once the total number of log files reaches `limitNumLogs`, each write API
+     * call will be blocked for `maxSleepTimeMs`, and the background flushers
+     * will immediately flush the log files. The sleep time will not exceed
+     * `maxSleepTimeMs`.
+     *
+     * If `maxSleepTimeMs` is set to zero, this feature will be disabled.
+     */
+    struct LogThrottlingOptions {
+        LogThrottlingOptions()
+            : startNumLogs(256)
+            , limitNumLogs(512)
+            , maxSleepTimeMs(0)
+            {}
+
+        /**
+         * The minimum number of log files initiates the throttling.
+         */
+        uint32_t startNumLogs;
+
+        /**
+         * The number of log files that will cause user threads to
+         * sleep for `maxSleepTimeMs`.
+         */
+        uint32_t limitNumLogs;
+
+        /**
+         * The maximum duration of sleep time.
+         */
+        uint32_t maxSleepTimeMs;
+    };
+
+    /**
+     * Log throttling option.
+     *
+     * It can be used to limit the overall memory consumption of the
+     * process occupied by memory tables corresponding to each log file.
+     */
+    LogThrottlingOptions ltOpt;
+
+    /**
      * Shutdown system logger on shutdown of Jungle.
      */
     bool shutdownLogger;

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -187,7 +187,9 @@ DBMgr::DBMgr()
     , twMgr(new TableWriterMgr())
     , gbExecutor(new GlobalBatchExecutor())
     , debugCbEnabled(false)
+    , globalTime(0)
     , idleTraffic(false)
+    , globalThrottlingMs(0)
     , myLog(nullptr)
 {
     updateGlobalTime();

--- a/src/db_mgr.h
+++ b/src/db_mgr.h
@@ -140,6 +140,16 @@ public:
 
     bool isDebugCallbackEffective() const { return debugCbEnabled.load(MOR); }
 
+    uint32_t setGlobalThrottling(uint32_t to) {
+        uint32_t prev = globalThrottlingMs.load(MOR);
+        globalThrottlingMs = to;
+        return prev;
+    }
+
+    uint32_t getGlobalThrottling() const {
+        return globalThrottlingMs.load(MOR);
+    }
+
 private:
     DBMgr();
 
@@ -193,6 +203,11 @@ private:
 
     // `true` if the current traffic to this process is idle.
     std::atomic<bool> idleTraffic;
+
+    /**
+     * Non-zero if global log throttling is active.
+     */
+    std::atomic<uint32_t> globalThrottlingMs;
 
     // Logger.
     SimpleLogger* myLog;

--- a/src/flusher.h
+++ b/src/flusher.h
@@ -84,6 +84,8 @@ public:
     ~Flusher();
     void work(WorkerOptions* opt_base);
 
+    void calcGlobalThrottling(size_t total_num_log_files);
+
     GlobalConfig gConfig;
     size_t lastCheckedFileIndex;
     FlusherType type;


### PR DESCRIPTION
* If there is heavy incoming traffic and the flush speed cannot keep up with the incoming write speed, the number of log files increases, and consequently the memory consumption also increases.

* This feature enables the throttling based on the total number of log files across all open DBs in the same process. User threads calling write APIs will be temporarily blocked if the throttling is active.