### PR TITLE
Added conan build and CMake cleanup and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ CMakeUserPresets.json
 compile_commands.json
 .cache
 .build_success*
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
+CMakeLists.txt
 CMakeUserPresets.json
-build/
-.cache/
 compile_commands.json
+.cache
+.build_success*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+CMakeUserPresets.json
+build/
+.cache/
+compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,65 +1,86 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 project(Jungle VERSION 1.0.0 LANGUAGES CXX)
 
+include(CTest) # automatically defines BUILD_TESTING option
+
+option(WITH_CONAN "Use dependences provide by Conan" OFF)
+option(SNAPPY_OPTION "Use Snappy Compression" ON)
+option(CODE_COVERAGE "Enable Coverage" OFF)
+option(ADDRESS_SANITIZER "Enable address sanitizer" OFF)
+option(THREAD_SANITIZER "Enable thread sanitizer" OFF)
+option(LEAK_SANITIZER "Enable leak sanitizer" OFF)
+option(BUILD_EXAMPLES "Build examples" ON)
+option(DETACH_LOGGER "Build libsimplelogger.a" ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # === Build type (default: RelWithDebInfo, O2) ===========
-if (NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE)
     set(BUILD_TYPE_OPTIONS
         "Choose the type of build, "
         "options are: Debug Release RelWithDebInfo MinSizeRel.")
     set(CMAKE_BUILD_TYPE "RelWithDebInfo"
         CACHE ${BUILD_TYPE_OPTIONS} FORCE)
     message(STATUS "Build type is not given, use default.")
-endif ()
+endif()
 message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 
 
 set(ROOT_SRC ${PROJECT_SOURCE_DIR}/src)
-set(CMAKE_DIR ${PROJECT_SOURCE_DIR}/cmake)
-set(FDB_LIB_DIR ${PROJECT_SOURCE_DIR}/third_party/forestdb/build)
+# set(CMAKE_DIR ${PROJECT_SOURCE_DIR}/cmake)
 
-if (CODE_COVERAGE GREATER 0)
+if(CODE_COVERAGE)
     set(CMAKE_BUILD_TYPE "Debug")
     include(cmake/CodeCoverage.cmake)
     message(STATUS "---- CODE COVERAGE DETECTION MODE ----")
 endif()
 
 # Libraries
-#set(LIBZ z)
 
-# Find snappy
-include(cmake/FindSnappy.cmake)
-if ( (SNAPPY_OPTION STREQUAL "Enable") OR
-     (SNAPPY_OPTION STREQUAL "enable") )
-    message(STATUS "Snappy option is enabled.")
-    if (SNAPPY_FOUND)
-        set(LIBSNAPPY ${SNAPPY_LIBRARIES})
-        add_definitions(-DSNAPPY_AVAILABLE=1)
+if(WITH_CONAN)
+    find_package(forestdb REQUIRED)
+    set(FORESTDB forestdb::forestdb)
+else()
+    set(FORESTDB ${CMAKE_CURRENT_SOURCE_DIR}/third_party/forestdb/build/libforestdb.a)
+    set(LIBZ z)
+endif()
+
+if(SNAPPY_OPTION)
+    if(WITH_CONAN)
+        find_package(Snappy REQUIRED)
+        set(LIBSNAPPY Snappy::snappy)
     else()
-        MESSAGE(FATAL_ERROR "Can't find snappy, "
-                "if you want to build without snappy set"
-                " \"-DSNAPPY_OPTION=Disable\"")
-    endif(SNAPPY_FOUND)
+        include(cmake/FindSnappy.cmake)
+        if(SNAPPY_FOUND)
+            set(LIBSNAPPY ${SNAPPY_LIBRARIES})
+        else()
+            message(FATAL_ERROR "Can't find snappy, "
+                "if you want to build without snappy set SNAPPY_OPTION=OFF")
+        endif(SNAPPY_FOUND)
+
+    endif(WITH_CONAN)
+    message(STATUS "Snappy option is enabled.")
+    add_compile_definitions(SNAPPY_AVAILABLE=1)
 endif()
 
 set(LIBDL dl)
 
 # Includes
-include_directories(BEFORE ./)
-include_directories(BEFORE ${PROJECT_SOURCE_DIR}/src)
-include_directories(BEFORE ${PROJECT_SOURCE_DIR}/include)
-include_directories(BEFORE ${PROJECT_SOURCE_DIR}/tools)
-include_directories(BEFORE ${PROJECT_SOURCE_DIR}/tests)
+include_directories(BEFORE
+    src
+    include
+    tools
+    tests
+    $<$<NOT:$<BOOL:${WITH_CONAN}>>:${CMAKE_CURRENT_SOURCE_DIR}/third_party/forestdb/include>
+)
 
-# Compiler flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pessimizing-move")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-if (NOT APPLE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-endif ()
+add_compile_options(
+    -g -Wall -Wno-pessimizing-move
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-vla-cxx-extension>
+    $<$<NOT:$<BOOL:${APPLE}>>:-pthread>
+)
 
-if (CODE_COVERAGE GREATER 0)
+if(CODE_COVERAGE)
     APPEND_COVERAGE_COMPILER_FLAGS()
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
     #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-inline")
@@ -77,18 +98,18 @@ endif()
 
 # === SANITIZER ===
 
-if (ADDRESS_SANITIZER GREATER 0)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fuse-ld=gold")
+if(ADDRESS_SANITIZER)
+    add_compile_options(-fsanitize=address -fuse-ld=gold)
     message(STATUS "---- ADDRESS SANITIZER IS ON ----")
 endif()
 
-if (THREAD_SANITIZER GREATER 0)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
+if(THREAD_SANITIZER)
+    add_compile_options(-fsanitize=thread)
     message(STATUS "---- THREAD SANITIZER IS ON ----")
 endif()
 
-if (LEAK_SANITIZER GREATER 0)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
+if(LEAK_SANITIZER)
+    add_compile_options(-fsanitize=leak)
     message(STATUS "---- LEAK SANITIZER IS ON ----")
 endif()
 
@@ -96,29 +117,29 @@ endif()
 
 # === Program flags ===
 
-if (TESTSUITE_NO_COLOR GREATER 0)
-    add_definitions(-DTESTSUITE_NO_COLOR=1)
+if(TESTSUITE_NO_COLOR GREATER 0)
+    add_compile_definitions(TESTSUITE_NO_COLOR=1)
     message(STATUS "---- MONOCOLOR TESTSUITE ----")
 endif()
 
-if (LOGGER_NO_BACKTRACE GREATER 0)
-    add_definitions(-DLOGGER_NO_BACKTRACE=1)
+if(LOGGER_NO_BACKTRACE GREATER 0)
+    add_compile_definitions(LOGGER_NO_BACKTRACE=1)
     message(STATUS "---- NO BACKTRACE BY LOGGER ----")
 endif()
 
 file(COPY ${PROJECT_SOURCE_DIR}/scripts/runtests.sh
-     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # === CUSTOM LOGGER ===
 
-if (LOGGER_PATH)
+if(LOGGER_PATH)
     set(LOGGER_CC_FILE "${LOGGER_PATH}/logger.cc")
     set(LOGGER_HEADER_FILE "${LOGGER_PATH}/logger.h")
-elseif (NOT LOGGER_CC_FILE)
+elseif(NOT LOGGER_CC_FILE)
     set(LOGGER_CC_FILE "${ROOT_SRC}/logger.cc")
     set(LOGGER_HEADER_FILE "${ROOT_SRC}/logger.h")
-endif ()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLOGGER_H=${LOGGER_HEADER_FILE}")
+endif()
+add_compile_definitions(LOGGER_H=${LOGGER_HEADER_FILE})
 message(STATUS "Simple logger cc file: ${LOGGER_CC_FILE}")
 message(STATUS "Simple logger header file: ${LOGGER_HEADER_FILE}")
 
@@ -126,18 +147,18 @@ message(STATUS "Simple logger header file: ${LOGGER_HEADER_FILE}")
 # === Source files ===================
 set(LOGGER_SRC ${LOGGER_CC_FILE})
 
-if (DETACH_LOGGER GREATER 0)
+if(DETACH_LOGGER)
     message(STATUS "---- DETACH LOGGER ----")
     set(LIBSIMPLELOGGER "${CMAKE_CURRENT_BINARY_DIR}/libsimplelogger.a")
 
     add_library(simplelogger_lib ${LOGGER_SRC})
     set_target_properties(simplelogger_lib PROPERTIES OUTPUT_NAME simplelogger
-                          CLEAN_DIRECT_OUTPUT 1)
+        CLEAN_DIRECT_OUTPUT 1)
 
-else ()
+else()
     set(LOGGER_SRC_TO_CORE ${LOGGER_SRC})
 
-endif ()
+endif()
 
 set(JUNGLE_CORE
     ${ROOT_SRC}/avltree.cc
@@ -189,7 +210,7 @@ set(JUNGLE_CORE
 
 # Note: static libraries MUST be located in front of all shared libraries.
 set(JUNGLE_DEPS
-    ${FDB_LIB_DIR}/libforestdb.a
+    ${FORESTDB}
     ${LIBSNAPPY}
     ${LIBDL})
 
@@ -197,41 +218,52 @@ add_library(static_lib ${JUNGLE_CORE})
 target_include_directories(static_lib PUBLIC "${PROJECT_SOURCE_DIR}/include")
 target_link_libraries(static_lib ${JUNGLE_DEPS})
 set_target_properties(static_lib PROPERTIES OUTPUT_NAME jungle
-                      CLEAN_DIRECT_OUTPUT 1)
-if (DETACH_LOGGER GREATER 0)
+    CLEAN_DIRECT_OUTPUT 1)
+if(DETACH_LOGGER GREATER 0)
     add_dependencies(static_lib simplelogger_lib)
-endif ()
+endif()
 
-add_subdirectory("${PROJECT_SOURCE_DIR}/examples")
-add_subdirectory("${PROJECT_SOURCE_DIR}/tests")
-add_subdirectory("${PROJECT_SOURCE_DIR}/tools")
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
 
-if (CODE_COVERAGE GREATER 0)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()
+
+add_subdirectory(tools)
+
+if(CODE_COVERAGE GREATER 0)
     SETUP_TARGET_FOR_COVERAGE(
         NAME jungle_cov
         EXECUTABLE ./runtests.sh
         DEPENDENCIES keyvalue_test
-                     crc32_test
-                     fileops_test
-                     fileops_directio_test
-                     memtable_test
-                     table_test
-                     basic_op_test
-                     sync_and_flush_test
-                     nearest_search_test
-                     seq_itr_test
-                     key_itr_test
-                     snapshot_test
-                     custom_cmp_test
-                     corruption_test
-                     compaction_test
-                     mt_test
-                     log_reclaim_test
-                     custom_mani_verifier
-                     level_extension_test
-                     table_lookup_booster_test
-                     compression_test
-                     atomic_batch_test
-                     builder_test
+        crc32_test
+        fileops_test
+        fileops_directio_test
+        memtable_test
+        table_test
+        basic_op_test
+        sync_and_flush_test
+        nearest_search_test
+        seq_itr_test
+        key_itr_test
+        snapshot_test
+        custom_cmp_test
+        corruption_test
+        compaction_test
+        mt_test
+        log_reclaim_test
+        custom_mani_verifier
+        level_extension_test
+        table_lookup_booster_test
+        compression_test
+        atomic_batch_test
+        builder_test
     )
 endif()
+
+install(DIRECTORY src/ DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY include/ DESTINATION include)
+install(FILES tools/mutable_table_mgr.h DESTINATION include/libjungle)
+install(TARGETS static_lib simplelogger_lib DESTINATION lib ARCHIVE DESTINATION lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,16 +101,19 @@ endif()
 
 if(ADDRESS_SANITIZER)
     add_compile_options(-fsanitize=address -fuse-ld=gold)
+    add_link_options(-fsanitize=address -fuse-ld=gold)
     message(STATUS "---- ADDRESS SANITIZER IS ON ----")
 endif()
 
 if(THREAD_SANITIZER)
     add_compile_options(-fsanitize=thread)
+    add_link_options(-fsanitize=thread)
     message(STATUS "---- THREAD SANITIZER IS ON ----")
 endif()
 
 if(LEAK_SANITIZER)
     add_compile_options(-fsanitize=leak)
+    add_link_options(-fsanitize=leak)
     message(STATUS "---- LEAK SANITIZER IS ON ----")
 endif()
 
@@ -150,7 +153,9 @@ set(LOGGER_SRC ${LOGGER_CC_FILE})
 
 if(DETACH_LOGGER)
     message(STATUS "---- DETACH LOGGER ----")
-    set(LIBSIMPLELOGGER "${CMAKE_CURRENT_BINARY_DIR}/libsimplelogger.a")
+    # set(LIBSIMPLELOGGER "${CMAKE_CURRENT_BINARY_DIR}/libsimplelogger.a")
+    # The proper/safe way is to pass the name of the target
+    set(LIBSIMPLELOGGER simplelogger_lib)
 
     add_library(simplelogger_lib ${LOGGER_SRC})
     set_target_properties(simplelogger_lib PROPERTIES OUTPUT_NAME simplelogger

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Jungle VERSION 1.0.0 LANGUAGES CXX)
 include(CTest) # automatically defines BUILD_TESTING option
 
 option(WITH_CONAN "Use dependences provide by Conan" OFF)
-option(SNAPPY_OPTION "Use Snappy Compression" ON)
+option(SNAPPY_OPTION "Use Snappy Compression" OFF)
 option(CODE_COVERAGE "Enable Coverage" OFF)
 option(ADDRESS_SANITIZER "Enable address sanitizer" OFF)
 option(THREAD_SANITIZER "Enable thread sanitizer" OFF)
@@ -27,7 +27,6 @@ message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
 
 
 set(ROOT_SRC ${PROJECT_SOURCE_DIR}/src)
-# set(CMAKE_DIR ${PROJECT_SOURCE_DIR}/cmake)
 
 if(CODE_COVERAGE)
     set(CMAKE_BUILD_TYPE "Debug")
@@ -39,7 +38,9 @@ endif()
 
 if(WITH_CONAN)
     find_package(forestdb REQUIRED)
+    find_package(ZLIB REQUIRED)
     set(FORESTDB forestdb::forestdb)
+    set(LIBZ ZLIB::ZLIB)
 else()
     set(FORESTDB ${CMAKE_CURRENT_SOURCE_DIR}/third_party/forestdb/build/libforestdb.a)
     set(LIBZ z)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ if(SNAPPY_OPTION)
 endif()
 
 set(LIBDL dl)
+set(LIBPTHREAD pthread)
 
 # Includes
 include_directories(BEFORE
@@ -218,6 +219,7 @@ set(JUNGLE_CORE
 set(JUNGLE_DEPS
     ${FORESTDB}
     ${LIBSNAPPY}
+    ${LIBPTHREAD}
     ${LIBDL})
 
 add_library(static_lib ${JUNGLE_CORE})

--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ Run unit tests:
 jungle/build$ ./runtests.sh
 ```
 
+Alternative build method - with Conan
+----------
+1. Install conan using one of the methods desribed here: https://conan.io/downloads
+1. `conan build .` - builds Release configuration
+1. `conan build . -s build_type=Debug` builds an alternative configuration supported by CMake
+1. Since Jungle depends on ForestDB, you need to do the same with ForestDB first and use it in **editable** mode
+1. You can control supported build options via command line as well, ex:
+    `conan build . -o build_tests=True` 
+
+
+
 
 How to Use
 ----------

--- a/cmake/FindSnappy.cmake
+++ b/cmake/FindSnappy.cmake
@@ -4,53 +4,53 @@
 #  LIBSNAPPY, Library path and libs
 #  SNAPPY_INCLUDE_DIR, where to find the ICU headers
 
-FIND_PATH(SNAPPY_INCLUDE_DIR snappy.h
-          HINTS
-               ENV SNAPPY_DIR
-          PATH_SUFFIXES include
-          PATHS
-               ~/Library/Frameworks
-               /Library/Frameworks
-               /usr/local
-               /opt/local
-               /opt/csw
-               /opt/snappy
-               /opt)
+find_path(SNAPPY_INCLUDE_DIR snappy.h
+  HINTS
+  ENV SNAPPY_DIR
+  PATH_SUFFIXES include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /opt/local
+  /opt/csw
+  /opt/snappy
+  /opt)
 
-FIND_LIBRARY(SNAPPY_LIBRARIES
-             NAMES snappy
-             HINTS
-                 ENV SNAPPY_DIR
-             PATHS
-                 ~/Library/Frameworks
-                 /Library/Frameworks
-                 /usr/local
-                 /opt/local
-                 /opt/csw
-                 /opt/snappy
-                 /opt)
+find_path(SNAPPY_LIBRARIES
+  NAMES snappy
+  HINTS
+  ENV SNAPPY_DIR
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /opt/local
+  /opt/csw
+  /opt/snappy
+  /opt)
 
-FIND_LIBRARY(SNAPPY_STATIC_LIBRARIES
-             NAMES libsnappy.a
-             HINTS
-                 ENV SNAPPY_DIR
-             PATHS
-                 ~/Library/Frameworks
-                 /Library/Frameworks
-                 /usr/local
-                 /opt/local
-                 /opt/csw
-                 /opt/snappy
-                 /opt)
+find_path(SNAPPY_STATIC_LIBRARIES
+  NAMES libsnappy.a
+  HINTS
+  ENV SNAPPY_DIR
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /usr/local
+  /opt/local
+  /opt/csw
+  /opt/snappy
+  /opt)
 
-IF (SNAPPY_LIBRARIES AND SNAPPY_INCLUDE_DIR )
+if(SNAPPY_LIBRARIES AND SNAPPY_INCLUDE_DIR)
   include_directories(AFTER ${SNAPPY_INCLUDE_DIR})
-  MESSAGE(STATUS "Found snappy in ${SNAPPY_INCLUDE_DIR} : ${SNAPPY_LIBRARIES}")
-  SET(SNAPPY_FOUND ON)
+  message(STATUS "Found snappy in ${SNAPPY_INCLUDE_DIR} : ${SNAPPY_LIBRARIES}")
+  set(SNAPPY_FOUND ON)
 
-   MARK_AS_ADVANCED(SNAPPY_INCLUDE_DIR SNAPPY_LIBRARIES)
-ELSE (SNAPPY_LIBRARIES AND SNAPPY_INCLUDE_DIR )
-  MESSAGE(STATUS "Snappy : NOT Found")
-  SET(SNAPPY_FOUND OFF)
+  mark_as_advanced(SNAPPY_INCLUDE_DIR SNAPPY_LIBRARIES)
+else()
+  message(STATUS "Snappy : NOT Found")
+  set(SNAPPY_FOUND OFF)
 
-ENDIF (SNAPPY_LIBRARIES AND SNAPPY_INCLUDE_DIR )
+endif(SNAPPY_LIBRARIES AND SNAPPY_INCLUDE_DIR)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,77 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain
+from conan.tools.files import copy
+from conan.tools.scm import Git
+
+required_conan_version = ">=2.12.2"
+
+class JungleConan(ConanFile):
+    name = "jungle"
+    package_type = "library"
+    license = "Apache-2.0"
+    homepage = "https://github.com/eBay/Jungle"
+
+    generators = "CMakeDeps"
+
+    settings = "os", "compiler", "build_type", "arch"
+
+    options = {
+        "shared": [True, False], 
+        "fPIC": [True, False],
+        "coverage": [True, False], 
+        "with_snappy" : [True, False],
+        "build_tests": [True, False],
+        "build_examples": [True, False]
+    }
+    default_options = {
+        "shared": False, 
+        "fPIC": True,
+        "with_snappy" : False,
+        "coverage": False,
+        "build_tests": False, 
+        "build_examples":False
+    }
+
+    exports_sources = "CMakeLists.txt", "src/*", "include/*", "cmake/*", "tools/*" "LICENSE"
+
+    def requirements(self):
+        self.requires("forestdb/[*]")
+        self.requires("zlib/[~1]")
+        if self.options.with_snappy:
+            self.requires("snappy/[~1]")
+
+    def layout(self):
+        cmake_layout(self, generator="CMakeDeps")
+        self.cpp.package.libs = [self.name, "simplelogger"]
+        self.cpp.source.includedirs = ["include", "src"]
+
+        hash = Git(self).get_commit()
+        self.cpp.package.defines = self.cpp.build.defines = ["_JUNGLE_COMMIT_HASH=%s" % hash]
+
+    
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["WITH_CONAN"] = True
+        tc.variables["CONAN_BUILD_COVERAGE"] = False
+        tc.variables["CODE_COVERAGE"] = self.options.coverage
+        tc.variables["SNAPPY_OPTION"] = self.options.with_snappy
+        tc.variables["BUILD_TESTING"] = self.options.build_tests
+        tc.variables["BUILD_EXAMPLES"] = self.options.build_examples
+        tc.variables["CMAKE_VERBOSE_MAKEFILE"] = True
+        tc.variables["CMAKE_EXPORT_COMPILE_COMMANDS"] = True
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+        if self.options.build_tests:
+            cmake.ctest()
+        copy(self, "compile_commands.json", self.build_folder, self.source_folder, keep_path=False)
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        assert copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses")), "LICENSE Copy failed"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,7 +3,7 @@ set(EXAMPLES_DIR ${PROJECT_SOURCE_DIR}/examples)
 set(JUNGLE_TEST_DEPS
     static_lib
     ${LIBSIMPLELOGGER}
-    ${FDB_LIB_DIR}/libforestdb.a
+    ${FORESTDB}
     ${LIBSNAPPY}
     ${LIBDL})
 
@@ -36,4 +36,9 @@ set(LOG_STORE ${EXAMPLES_DIR}/example_log_store_mode.cc)
 add_executable(log_store ${LOG_STORE})
 target_link_libraries(log_store ${JUNGLE_TEST_DEPS})
 add_dependencies(log_store static_lib)
- 
+
+install(TARGETS
+    get_set_del iterator iterator_adv snapshot_checkpoint snapshot_instant
+    log_store
+    RUNTIME DESTINATION bin
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,8 +4,7 @@ set(JUNGLE_TEST_DEPS
     static_lib
     ${LIBSIMPLELOGGER}
     ${FORESTDB}
-    ${LIBSNAPPY}
-    ${LIBDL})
+    ${LIBSNAPPY})
 
 set(GET_SET_DEL ${EXAMPLES_DIR}/example_get_set_del.cc)
 add_executable(get_set_del ${GET_SET_DEL})

--- a/src/cmd_handler.cc
+++ b/src/cmd_handler.cc
@@ -22,7 +22,7 @@ limitations under the License.
 #include "skiplist.h"
 #include "table_mgr.h"
 
-#include <third_party/forestdb/include/libforestdb/forestdb.h>
+#include <libforestdb/forestdb.h>
 
 #include <iostream>
 #include <sstream>

--- a/src/skiplist.cc
+++ b/src/skiplist.cc
@@ -81,10 +81,13 @@ limitations under the License.
 
     #define MOR                         __ATOMIC_RELAXED
     #define ATM_GET(var)                (var)
-    #define ATM_LOAD(var, val)          __atomic_load(&(var), &(val), MOR)
-    #define ATM_STORE(var, val)         __atomic_store(&(var), &(val), MOR)
+    #define ATM_LOAD(var, val)          __atomic_load(&(var), reinterpret_cast<decltype(&(var))>(&(val)), MOR)
+    #define ATM_STORE(var, val)         __atomic_store(&(var), reinterpret_cast<decltype(&(var))>(&(val)), MOR)
     #define ATM_CAS(var, exp, val)      \
-            __atomic_compare_exchange(&(var), &(exp), &(val), 1, MOR, MOR)
+            __atomic_compare_exchange(&(var), \
+                reinterpret_cast<decltype(&(var))>(&(exp)), \
+                reinterpret_cast<decltype(&(var))>(&(val)), \
+                1, MOR, MOR)
     #define ATM_FETCH_ADD(var, val)     __atomic_fetch_add(&(var), (val), MOR)
     #define ATM_FETCH_SUB(var, val)     __atomic_fetch_sub(&(var), (val), MOR)
     #define ALLOC_(type, var, count)    \

--- a/src/table_file.cc
+++ b/src/table_file.cc
@@ -21,7 +21,7 @@ limitations under the License.
 #include "internal_helper.h"
 #include "table_mgr.h"
 
-#include <third_party/forestdb/include/libforestdb/fdb_types.h>
+#include <libforestdb/fdb_types.h>
 
 #include _MACRO_TO_STR(LOGGER_H)
 

--- a/src/table_file.h
+++ b/src/table_file.h
@@ -21,7 +21,7 @@ limitations under the License.
 #include "table_lookup_booster.h"
 
 #include <libjungle/jungle.h>
-#include <third_party/forestdb/include/libforestdb/forestdb.h>
+#include <libforestdb/forestdb.h>
 
 #include <list>
 #include <map>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,8 +7,7 @@ set(JUNGLE_TEST_DEPS
     static_lib
     ${LIBSIMPLELOGGER}
     ${FORESTDB}
-    ${LIBSNAPPY}
-    ${LIBDL})
+    ${LIBSNAPPY})
 
 
 function(unit_test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,196 +6,118 @@ set(STRESS_TEST_DIR ${TEST_DIR}/stress)
 set(JUNGLE_TEST_DEPS
     static_lib
     ${LIBSIMPLELOGGER}
-    ${FDB_LIB_DIR}/libforestdb.a
+    ${FORESTDB}
     ${LIBSNAPPY}
     ${LIBDL})
 
-set(FILEOPS_TEST ${TEST_DIR}/unit/fileops_test.cc)
-add_executable(fileops_test ${FILEOPS_TEST})
-target_link_libraries(fileops_test ${JUNGLE_TEST_DEPS})
-add_dependencies(fileops_test static_lib)
 
-set(FILEOPS_DIRECTIO_TEST ${TEST_DIR}/unit/fileops_directio_test.cc)
-add_executable(fileops_directio_test ${FILEOPS_DIRECTIO_TEST})
-target_link_libraries(fileops_directio_test ${JUNGLE_TEST_DEPS})
-add_dependencies(fileops_directio_test static_lib)
+function(unit_test)
+    set(options SKIP)
+    set(oneValueArgs NAME TIMEOUT)
+    set(multiValueArgs SOURCES ARGS)
+    cmake_parse_arguments(PARSE_ARGV 0 arg
+        "${options}" "${oneValueArgs}" "${multiValueArgs}"
+    )
 
-set(KEYVALUE_TEST ${TEST_DIR}/unit/keyvalue_test.cc)
-add_executable(keyvalue_test ${KEYVALUE_TEST})
-target_link_libraries(keyvalue_test ${JUNGLE_TEST_DEPS})
-add_dependencies(keyvalue_test static_lib)
+    add_executable(${arg_NAME} ${arg_SOURCES})
+    target_link_libraries(${arg_NAME} ${JUNGLE_TEST_DEPS})
+    if(NOT arg_SKIP)
+        add_test(NAME ${arg_NAME} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${arg_NAME} --abort-on-failure ${arg_ARGS})
+        if(arg_TIMEOUT)
+            set_tests_properties(${arg_NAME} PROPERTIES TIMEOUT ${arg_TIMEOUT})
+        endif()
+    endif()
+endfunction()
 
-set(MEMTABLE_TEST ${TEST_DIR}/unit/memtable_test.cc)
-add_executable(memtable_test ${MEMTABLE_TEST})
-target_link_libraries(memtable_test ${JUNGLE_TEST_DEPS})
-add_dependencies(memtable_test static_lib)
+unit_test(NAME fileops_test SOURCES ${TEST_DIR}/unit/fileops_test.cc)
 
-set(TABLE_TEST ${TEST_DIR}/unit/table_test.cc)
-add_executable(table_test ${TABLE_TEST})
-target_link_libraries(table_test ${JUNGLE_TEST_DEPS})
-add_dependencies(table_test static_lib)
+unit_test(NAME fileops_directio_test SOURCES ${TEST_DIR}/unit/fileops_directio_test.cc)
 
-set(CRC32_TEST ${TEST_DIR}/unit/crc32_test.cc)
-add_executable(crc32_test ${CRC32_TEST})
-target_link_libraries(crc32_test ${JUNGLE_TEST_DEPS})
-add_dependencies(crc32_test static_lib)
+unit_test(NAME keyvalue_test SOURCES ${TEST_DIR}/unit/keyvalue_test.cc)
 
-set(TABLE_LOOKUP_BOOSTER_TEST ${TEST_DIR}/unit/table_lookup_booster_test.cc)
-add_executable(table_lookup_booster_test ${TABLE_LOOKUP_BOOSTER_TEST})
-target_link_libraries(table_lookup_booster_test ${JUNGLE_TEST_DEPS})
-add_dependencies(table_lookup_booster_test static_lib)
+unit_test(NAME memtable_test SOURCES ${TEST_DIR}/unit/memtable_test.cc)
 
-add_custom_target(unit_test)
-add_dependencies(unit_test
-                 fileops_test
-                 fileops_directio_test
-                 keyvalue_test
-                 crc32_test)
+unit_test(NAME table_test SOURCES ${TEST_DIR}/unit/table_test.cc)
 
-set(BASIC_OP_TEST ${TEST_DIR}/jungle/basic_op_test.cc)
-add_executable(basic_op_test ${BASIC_OP_TEST})
-target_link_libraries(basic_op_test ${JUNGLE_TEST_DEPS})
-add_dependencies(basic_op_test static_lib)
+unit_test(NAME crc32_test SOURCES ${TEST_DIR}/unit/crc32_test.cc)
 
-set(SYNC_AND_FLUSH_TEST ${TEST_DIR}/jungle/sync_and_flush_test.cc)
-add_executable(sync_and_flush_test ${SYNC_AND_FLUSH_TEST})
-target_link_libraries(sync_and_flush_test ${JUNGLE_TEST_DEPS})
-add_dependencies(sync_and_flush_test static_lib)
+unit_test(NAME table_lookup_booster_test SOURCES ${TEST_DIR}/unit/table_lookup_booster_test.cc)
 
-set(NEAREST_SEARCH_TEST ${TEST_DIR}/jungle/nearest_search_test.cc)
-add_executable(nearest_search_test ${NEAREST_SEARCH_TEST})
-target_link_libraries(nearest_search_test ${JUNGLE_TEST_DEPS})
-add_dependencies(nearest_search_test static_lib)
+add_custom_target(unit_tests)
+add_dependencies(unit_tests
+    fileops_test
+    fileops_directio_test
+    keyvalue_test
+    crc32_test)
 
-set(BUILDER_TEST ${TEST_DIR}/jungle/builder_test.cc)
-add_executable(builder_test ${BUILDER_TEST})
-target_link_libraries(builder_test ${JUNGLE_TEST_DEPS})
-add_dependencies(builder_test static_lib)
+unit_test(NAME basic_op_test SOURCES ${TEST_DIR}/jungle/basic_op_test.cc)
 
-set(SEQ_ITR_TEST ${TEST_DIR}/jungle/seq_itr_test.cc)
-add_executable(seq_itr_test ${SEQ_ITR_TEST})
-target_link_libraries(seq_itr_test ${JUNGLE_TEST_DEPS})
-add_dependencies(seq_itr_test static_lib)
+unit_test(NAME sync_and_flush_test SOURCES ${TEST_DIR}/jungle/sync_and_flush_test.cc)
 
-set(KEY_ITR_TEST ${TEST_DIR}/jungle/key_itr_test.cc)
-add_executable(key_itr_test ${KEY_ITR_TEST})
-target_link_libraries(key_itr_test ${JUNGLE_TEST_DEPS})
-add_dependencies(key_itr_test static_lib)
+unit_test(NAME nearest_search_test SOURCES ${TEST_DIR}/jungle/nearest_search_test.cc)
 
-set(SNAPSHOT_TEST ${TEST_DIR}/jungle/snapshot_test.cc)
-add_executable(snapshot_test ${SNAPSHOT_TEST})
-target_link_libraries(snapshot_test ${JUNGLE_TEST_DEPS})
-add_dependencies(snapshot_test static_lib)
+unit_test(NAME builder_test SOURCES ${TEST_DIR}/jungle/builder_test.cc)
 
-set(CUSTOM_CMP_TEST ${TEST_DIR}/jungle/custom_cmp_test.cc)
-add_executable(custom_cmp_test ${CUSTOM_CMP_TEST})
-target_link_libraries(custom_cmp_test ${JUNGLE_TEST_DEPS})
-add_dependencies(custom_cmp_test static_lib)
+unit_test(NAME seq_itr_test SOURCES ${TEST_DIR}/jungle/seq_itr_test.cc)
 
-set(CORRUPTION_TEST ${TEST_DIR}/jungle/corruption_test.cc)
-add_executable(corruption_test ${CORRUPTION_TEST})
-target_link_libraries(corruption_test ${JUNGLE_TEST_DEPS})
-add_dependencies(corruption_test static_lib)
+unit_test(NAME key_itr_test SOURCES ${TEST_DIR}/jungle/key_itr_test.cc)
 
-set(COMPACTION_TEST ${TEST_DIR}/jungle/compaction_test.cc)
-add_executable(compaction_test ${COMPACTION_TEST})
-target_link_libraries(compaction_test ${JUNGLE_TEST_DEPS})
-add_dependencies(compaction_test static_lib)
+unit_test(NAME snapshot_test SOURCES ${TEST_DIR}/jungle/snapshot_test.cc)
 
-set(LEVEL_EXT_TEST ${TEST_DIR}/jungle/level_extension_test.cc)
-add_executable(level_extension_test ${LEVEL_EXT_TEST})
-target_link_libraries(level_extension_test ${JUNGLE_TEST_DEPS})
-add_dependencies(level_extension_test static_lib)
+unit_test(NAME custom_cmp_test SOURCES ${TEST_DIR}/jungle/custom_cmp_test.cc)
 
-set(LOG_RECLAIM_TEST ${TEST_DIR}/jungle/log_reclaim_test.cc)
-add_executable(log_reclaim_test ${LOG_RECLAIM_TEST})
-target_link_libraries(log_reclaim_test ${JUNGLE_TEST_DEPS})
-add_dependencies(log_reclaim_test static_lib)
+unit_test(NAME corruption_test SOURCES ${TEST_DIR}/jungle/corruption_test.cc)
 
-set(CUSTOM_MANI_VERIFIER ${TEST_DIR}/jungle/custom_mani_verifier.cc)
-add_executable(custom_mani_verifier ${CUSTOM_MANI_VERIFIER})
-target_link_libraries(custom_mani_verifier ${JUNGLE_TEST_DEPS})
-add_dependencies(custom_mani_verifier static_lib)
+unit_test(NAME compaction_test SOURCES ${TEST_DIR}/jungle/compaction_test.cc)
 
-set(COMPRESSION_TEST ${TEST_DIR}/jungle/compression_test.cc)
-add_executable(compression_test ${COMPRESSION_TEST})
-target_link_libraries(compression_test ${JUNGLE_TEST_DEPS})
-add_dependencies(compression_test static_lib)
+unit_test(NAME level_extension_test SOURCES ${TEST_DIR}/jungle/level_extension_test.cc)
 
-set(MT_TEST ${TEST_DIR}/jungle/mt_test.cc)
-add_executable(mt_test ${MT_TEST})
-target_link_libraries(mt_test ${JUNGLE_TEST_DEPS})
-add_dependencies(mt_test static_lib)
+unit_test(NAME log_reclaim_test SOURCES ${TEST_DIR}/jungle/log_reclaim_test.cc)
 
-set(LARGE_TEST ${TEST_DIR}/jungle/large_test.cc)
-add_executable(large_test ${LARGE_TEST})
-target_link_libraries(large_test ${JUNGLE_TEST_DEPS})
-add_dependencies(large_test static_lib)
+unit_test(NAME custom_mani_verifier SOURCES ${TEST_DIR}/jungle/custom_mani_verifier.cc SKIP)
 
-set(ATOMIC_BATCH_TEST ${TEST_DIR}/jungle/atomic_batch_test.cc)
-add_executable(atomic_batch_test ${ATOMIC_BATCH_TEST})
-target_link_libraries(atomic_batch_test ${JUNGLE_TEST_DEPS})
-add_dependencies(atomic_batch_test static_lib)
+unit_test(NAME compression_test SOURCES ${TEST_DIR}/jungle/compression_test.cc)
+
+unit_test(NAME mt_test SOURCES ${TEST_DIR}/jungle/mt_test.cc)
+
+unit_test(NAME large_test SOURCES ${TEST_DIR}/jungle/large_test.cc)
+
+unit_test(NAME atomic_batch_test SOURCES ${TEST_DIR}/jungle/atomic_batch_test.cc)
 
 add_custom_target(func_test)
 add_dependencies(func_test
-                 basic_op_test
-                 seq_itr_test
-                 key_itr_test
-                 snapshot_test
-                 custom_cmp_test
-                 mt_test
-                 large_test
-                 atomic_batch_test)
+    basic_op_test
+    seq_itr_test
+    key_itr_test
+    snapshot_test
+    custom_cmp_test
+    mt_test
+    large_test
+    atomic_batch_test)
 
 
-set(FLUSH_ST_TEST ${TEST_DIR}/stress/flush_stress_test.cc)
-add_executable(flush_stress_test ${FLUSH_ST_TEST})
-target_link_libraries(flush_stress_test ${JUNGLE_TEST_DEPS})
-add_dependencies(flush_stress_test static_lib)
+unit_test(NAME flush_stress_test SOURCES ${TEST_DIR}/stress/flush_stress_test.cc)
 
-set(PURGE_ST_TEST ${TEST_DIR}/stress/purge_stress_test.cc)
-add_executable(purge_stress_test ${PURGE_ST_TEST})
-target_link_libraries(purge_stress_test ${JUNGLE_TEST_DEPS})
-add_dependencies(purge_stress_test static_lib)
+unit_test(NAME purge_stress_test SOURCES ${TEST_DIR}/stress/purge_stress_test.cc)
 
-set(ITR_ST_TEST ${TEST_DIR}/stress/iterator_stress_test.cc)
-add_executable(iterator_stress_test ${ITR_ST_TEST})
-target_link_libraries(iterator_stress_test ${JUNGLE_TEST_DEPS})
-add_dependencies(iterator_stress_test static_lib)
+unit_test(NAME iterator_stress_test SOURCES ${TEST_DIR}/stress/iterator_stress_test.cc)
 
-set(COMPACT_ST_TEST ${TEST_DIR}/stress/compactor_stress_test.cc)
-add_executable(compactor_stress_test ${COMPACT_ST_TEST})
-target_link_libraries(compactor_stress_test ${JUNGLE_TEST_DEPS})
-add_dependencies(compactor_stress_test static_lib)
+unit_test(NAME compactor_stress_test SOURCES ${TEST_DIR}/stress/compactor_stress_test.cc)
 
-set(LOG_RC_ST_TEST ${TEST_DIR}/stress/log_reclaim_stress_test.cc)
-add_executable(log_reclaim_stress_test ${LOG_RC_ST_TEST})
-target_link_libraries(log_reclaim_stress_test ${JUNGLE_TEST_DEPS})
-add_dependencies(log_reclaim_stress_test static_lib)
+unit_test(NAME log_reclaim_stress_test SOURCES ${TEST_DIR}/stress/log_reclaim_stress_test.cc)
 
-set(MANY_LOG_TEST ${TEST_DIR}/stress/many_log_files_test.cc)
-add_executable(many_log_files_test ${MANY_LOG_TEST})
-target_link_libraries(many_log_files_test ${JUNGLE_TEST_DEPS})
-add_dependencies(many_log_files_test static_lib)
+unit_test(NAME many_log_files_test SOURCES ${TEST_DIR}/stress/many_log_files_test.cc)
 
 add_custom_target(stress_test)
 add_dependencies(stress_test
-                 flush_stress_test
-                 purge_stress_test
-                 many_log_files_test)
+    flush_stress_test
+    purge_stress_test
+    many_log_files_test)
 
 
-set(BASIC_ROBUST_CHILD ${TEST_DIR}/robust/basic_robust_child.cc)
-add_executable(basic_robust_child ${BASIC_ROBUST_CHILD})
-target_link_libraries(basic_robust_child ${JUNGLE_TEST_DEPS})
-add_dependencies(basic_robust_child static_lib)
+unit_test(NAME basic_robust_child SOURCES ${TEST_DIR}/robust/basic_robust_child.cc)
 
-set(DIST_TEST
-    ${TEST_DIR}/bench/dist_def_test.cc)
-add_executable(dist_test ${DIST_TEST})
-target_link_libraries(dist_test ${JUNGLE_TEST_DEPS})
-add_dependencies(dist_test static_lib)
+unit_test(NAME dist_test SOURCES ${TEST_DIR}/bench/dist_def_test.cc)
 
 
 # --- Benchmark ---
@@ -205,8 +127,17 @@ set(BENCH
     ${TEST_DIR}/bench/db_adapter_jungle.cc)
 add_executable(jungle_bench ${BENCH})
 set_target_properties(jungle_bench
-                      PROPERTIES COMPILE_FLAGS
-                      "-DJUNGLE_ADAPTER=1")
+    PROPERTIES COMPILE_FLAGS
+    "-DJUNGLE_ADAPTER=1")
 target_link_libraries(jungle_bench ${JUNGLE_TEST_DEPS})
-add_dependencies(jungle_bench static_lib)
+
+
+
+install(TARGETS
+    basic_robust_child
+    custom_mani_verifier
+    jungle_bench
+    RUNTIME DESTINATION bin
+)
+
 

--- a/tests/bench/dist_def.h
+++ b/tests/bench/dist_def.h
@@ -169,7 +169,7 @@ struct DistDef {
         uint64_t rr[2];
         MurmurHash3_x64_128(&index, sizeof(index), 0, rr);
 
-        double z = (double)rr[0] / std::numeric_limits<uint64_t>::max();
+        double z = (double)rr[0] / (double)std::numeric_limits<uint64_t>::max();
         auto iter = zProbs.lower_bound(z);
         assert(iter != zProbs.end());
         return iter->second - 1;

--- a/tests/unit/table_test.cc
+++ b/tests/unit/table_test.cc
@@ -17,7 +17,7 @@ limitations under the License.
 #include "db_mgr.h"
 #include "fileops_posix.h"
 #include "table_file.h"
-#include "tools/mutable_table_mgr.h"
+#include "mutable_table_mgr.h"
 
 #include "libjungle/jungle.h"
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,8 +4,7 @@ set(JUNGLE_TOOLS_DEPS
     static_lib
     ${LIBSIMPLELOGGER}
     ${FORESTDB}
-    ${LIBSNAPPY}
-    ${LIBDL})
+    ${LIBSNAPPY})
 
 set(BF_GEN ${TOOLS_DIR}/bloomfilter_generator.cc)
 add_executable(bloomfilter_generator ${BF_GEN})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,7 +3,7 @@ set(TOOLS_DIR ${PROJECT_SOURCE_DIR}/tools)
 set(JUNGLE_TOOLS_DEPS
     static_lib
     ${LIBSIMPLELOGGER}
-    ${FDB_LIB_DIR}/libforestdb.a
+    ${FORESTDB}
     ${LIBSNAPPY}
     ${LIBDL})
 
@@ -16,3 +16,8 @@ set(JUNGLE_CHECKER ${TOOLS_DIR}/jungle_checker.cc)
 add_executable(jungle_checker ${JUNGLE_CHECKER})
 target_link_libraries(jungle_checker ${JUNGLE_TOOLS_DEPS})
 add_dependencies(jungle_checker static_lib)
+
+install(TARGETS
+    bloomfilter_generator jungle_checker
+    RUNTIME DESTINATION bin
+)


### PR DESCRIPTION
This adds support for local conan builds `conan build .` etc and works in conan edtiable mode which makes it possible to easily integrate with conan-based projects.

The traditional build method is intact.

Other changes:
1. cmake cleanup
2.  added unit_test function to automatically expose all unit tests to cmake/ctest
3. Added type case in  ATM_LOAD/ATM_STORE in skiplist.cpp to build wit clang. This is needed because `bool* != unsigned char*` . Feel free to adjust as needed but check the build with clang
4. Added build note in readme.md