### PR TITLE
Fix to flush and DB close race condition

### DIFF
--- a/include/libjungle/params.h
+++ b/include/libjungle/params.h
@@ -308,6 +308,13 @@ struct DebugParams {
     std::function< void(const GenericCbParams&) > logFlushCb;
 
     /**
+     * Callback function that will be invoked right after
+     * the manifest's last flushed log file number, but before
+     * removing the stale log files.
+     */
+    std::function< void(const GenericCbParams&) > logFlushBeforeRemoveCb;
+
+    /**
      * Callback function that will be invoked at the beginning log sync
      * (reading memtable data and writing them into log files).
      */

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -377,7 +377,7 @@ Status LogManifest::load(const std::string& path,
             synced_seq = last_synced_seq;
         }
 
-        if (l_file_num < lastFlushedLog) {
+        if (valid_number(lastFlushedLog) && l_file_num < lastFlushedLog) {
             // If the log file number is less than last flushed log,
             // it is not valid.
             _log_warn(myLog, "log file %zu is less than last flushed log %zu, "

--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -377,6 +377,16 @@ Status LogManifest::load(const std::string& path,
             synced_seq = last_synced_seq;
         }
 
+        if (l_file_num < lastFlushedLog) {
+            // If the log file number is less than last flushed log,
+            // it is not valid.
+            _log_warn(myLog, "log file %zu is less than last flushed log %zu, "
+                      "skip it",
+                      l_file_num, lastFlushedLog.load());
+            delete l_file;
+            continue;
+        }
+
         s = l_file->load(l_filename, fLogOps, l_file_num,
                          min_seq, purged_seq, synced_seq);
         if (!s) {

--- a/tests/jungle/corruption_test.cc
+++ b/tests/jungle/corruption_test.cc
@@ -371,7 +371,7 @@ int discontinued_stale_log_file_test() {
 
     // Insert 55 keys.
     for (size_t ii = 0; ii < 55; ++ii) {
-        std::string key_str = key_prefix + TestSuite::lzStr(3, ii);;
+        std::string key_str = key_prefix + TestSuite::lzStr(3, ii);
         std::string val_str = val_prefix + TestSuite::lzStr(3, ii);
         CHK_Z(db->set(jungle::KV(key_str, val_str)));
     }
@@ -410,7 +410,7 @@ int discontinued_stale_log_file_test() {
 
     // Insert 25 more keys.
     for (size_t ii = 55; ii < 80; ++ii) {
-        std::string key_str = key_prefix + TestSuite::lzStr(3, ii);;
+        std::string key_str = key_prefix + TestSuite::lzStr(3, ii);
         std::string val_str = val_prefix + TestSuite::lzStr(3, ii);
         CHK_Z(db2->set(jungle::KV(key_str, val_str)));
     }


### PR DESCRIPTION
* If DB is closed while background flush is going on, the manifest file many contain intermediate state. It should be gracefully handled on the next DB open.

* The last sync on DB close should be done after making sure that there is no more sync or flush thread.