### PR TITLE
Add a new API `updateGlobalConfig`

### DIFF
--- a/include/libjungle/jungle.h
+++ b/include/libjungle/jungle.h
@@ -80,6 +80,14 @@ public:
     static Status shutdown();
 
     /**
+     * Update global configurations on-the-fly.
+     *
+     * @param new_config New global configurations to apply.
+     * @return OK on success.
+     */
+    static Status updateGlobalConfig(const GlobalConfig& new_config);
+
+    /**
      * Open a Jungle instance in the given path.
      * If the given path is empty, create a new one.
      *
@@ -699,6 +707,17 @@ static inline Status init(const GlobalConfig& global_config) {
 static inline Status shutdown() {
     (void)shutdown;
     return DB::shutdown();
+}
+
+/**
+ * Update global configurations on-the-fly.
+ *
+ * @param new_config New global configurations to apply.
+ * @return OK on success.
+ */
+static inline Status updateGlobalConfig(const GlobalConfig& new_config) {
+    (void)updateGlobalConfig;
+    return DB::updateGlobalConfig(new_config);
 }
 
 /**

--- a/src/cmd_handler.cc
+++ b/src/cmd_handler.cc
@@ -31,22 +31,27 @@ limitations under the License.
 
 namespace jungle {
 
-CmdHandler::CmdHandler( const std::string& _w_name,
-                        const GlobalConfig& _config )
+CmdHandler::CmdHandler( const std::string& wn,
+                        const GlobalConfig& c )
 {
-    workerName = _w_name;
-    gConfig = _config;
+    workerName = wn;
+    applyNewGlobalConfig(c);
+    handle = std::thread(&WorkerBase::loop, this);
+}
+
+void CmdHandler::applyNewGlobalConfig(const GlobalConfig& g_config) {
+    gConfig = g_config;
     CmdHandlerOptions options;
-    options.sleepDuration_ms = 1000;
+    options.sleepDurationMs = 1000;
     options.worker = this;
     curOptions = options;
-    handle = std::thread(WorkerBase::loop, &curOptions);
 }
+
 
 CmdHandler::~CmdHandler() {
 }
 
-void CmdHandler::work(WorkerOptions* opt_base) {
+void CmdHandler::work() {
     Status s;
 
     DBMgr* dbm = DBMgr::getWithoutInit();

--- a/src/cmd_handler.h
+++ b/src/cmd_handler.h
@@ -28,12 +28,14 @@ public:
     struct CmdHandlerOptions : public WorkerOptions {
     };
 
-    CmdHandler(const std::string& _w_name,
-              const GlobalConfig& _config);
-    ~CmdHandler();
-    void work(WorkerOptions* opt_base);
+    CmdHandler(const std::string& wn,
+               const GlobalConfig& c);
 
-    GlobalConfig gConfig;
+    ~CmdHandler();
+
+    void applyNewGlobalConfig(const GlobalConfig& g_config);
+
+    void work();
 
 private:
     void handleCmd(DBWrap* target_dbw);

--- a/src/compactor.cc
+++ b/src/compactor.cc
@@ -29,18 +29,22 @@ limitations under the License.
 
 namespace jungle {
 
-Compactor::Compactor( const std::string& _w_name,
-                      const GlobalConfig& _config )
+Compactor::Compactor( const std::string& wn,
+                      const GlobalConfig& c )
     : lastCheckedFileIndex(0xffff) // Any big number to start from 0.
     , lastCompactedHashNum(0)
 {
-    workerName = _w_name;
-    gConfig = _config;
+    workerName = wn;
+    applyNewGlobalConfig(c);
+    handle = std::thread(&WorkerBase::loop, this);
+}
+
+void Compactor::applyNewGlobalConfig(const GlobalConfig& g_config) {
+    gConfig = g_config;
     CompactorOptions options;
-    options.sleepDuration_ms = gConfig.compactorSleepDuration_ms;
+    options.sleepDurationMs = gConfig.compactorSleepDuration_ms;
     options.worker = this;
     curOptions = options;
-    handle = std::thread(WorkerBase::loop, &curOptions);
 }
 
 Compactor::~Compactor() {
@@ -95,7 +99,7 @@ bool Compactor::chkLevel(size_t level,
     return false;
 }
 
-void Compactor::work(WorkerOptions* opt_base) {
+void Compactor::work() {
     Status s;
 
     DBMgr* dbm = DBMgr::getWithoutInit();

--- a/src/compactor.h
+++ b/src/compactor.h
@@ -33,12 +33,13 @@ public:
     struct CompactorOptions : public WorkerOptions {
     };
 
-    Compactor(const std::string& _w_name,
-              const GlobalConfig& _config);
+    Compactor(const std::string& wn,
+              const GlobalConfig& c);
     ~Compactor();
-    void work(WorkerOptions* opt_base);
 
-    GlobalConfig gConfig;
+    void applyNewGlobalConfig(const GlobalConfig& g_config);
+
+    void work();
 
 private:
     bool chkLevel(size_t level,

--- a/src/db_mgr.cc
+++ b/src/db_mgr.cc
@@ -184,6 +184,16 @@ void DBMgr::initInternal(const GlobalConfig& config) {
     twMgr->init();
 }
 
+Status DBMgr::updateGlobalConfig(const GlobalConfig& new_config) {
+    gConfig = new_config;
+    _log_info(myLog, "updating global config");
+    printGlobalConfig();
+    wMgr->updateGlobalConfig(new_config);
+    _log_info(myLog, "updated global config, each worker will apply it after "
+              "finishing current task");
+    return Status();
+}
+
 DBMgr* DBMgr::get() {
     DBMgr* mgr = instance.load(MOR);
     if (!mgr) {

--- a/src/db_mgr.h
+++ b/src/db_mgr.h
@@ -84,6 +84,8 @@ public:
     static DBMgr* getWithoutInit();
     static void destroy();
 
+    Status updateGlobalConfig(const GlobalConfig& new_config);
+
     Status addLogReclaimer();
 
     DB* openExisting(const std::string& path, const std::string& kvs_name);

--- a/src/flusher.cc
+++ b/src/flusher.cc
@@ -86,15 +86,19 @@ Flusher::Flusher(const std::string& w_name,
     : lastCheckedFileIndex(0xffff) // Any big number to start from 0.
     , type(f_type) {
     workerName = w_name;
-    gConfig = g_config;
-    FlusherOptions options;
-    options.sleepDuration_ms = gConfig.flusherSleepDuration_ms;
-    options.worker = this;
-    curOptions = options;
-    handle = std::thread(WorkerBase::loop, &curOptions);
+    applyNewGlobalConfig(g_config);
+    handle = std::thread(&WorkerBase::loop, this);
 }
 
 Flusher::~Flusher() {
+}
+
+void Flusher::applyNewGlobalConfig(const GlobalConfig& g_config) {
+    gConfig = g_config;
+    FlusherOptions options;
+    options.sleepDurationMs = gConfig.flusherSleepDuration_ms;
+    options.worker = this;
+    curOptions = options;
 }
 
 void Flusher::calcGlobalThrottling(size_t total_num_log_files) {
@@ -132,7 +136,7 @@ void Flusher::calcGlobalThrottling(size_t total_num_log_files) {
     }
 }
 
-void Flusher::work(WorkerOptions* opt_base) {
+void Flusher::work() {
     Status s;
 
     DBMgr* dbm = DBMgr::getWithoutInit();

--- a/src/flusher.h
+++ b/src/flusher.h
@@ -82,11 +82,12 @@ public:
             const GlobalConfig& g_config,
             FlusherType f_type = FlusherType::GENERIC);
     ~Flusher();
-    void work(WorkerOptions* opt_base);
+    void work();
+
+    void applyNewGlobalConfig(const GlobalConfig& g_config);
 
     void calcGlobalThrottling(size_t total_num_log_files);
 
-    GlobalConfig gConfig;
     size_t lastCheckedFileIndex;
     FlusherType type;
 };

--- a/src/jungle.cc
+++ b/src/jungle.cc
@@ -246,6 +246,13 @@ Status DB::shutdown() {
     return Status();
 }
 
+Status DB::updateGlobalConfig(const GlobalConfig& new_config) {
+    DBMgr* mgr = DBMgr::getWithoutInit();
+    if (!mgr) return Status::NOT_INITIALIZED;
+
+    return mgr->updateGlobalConfig(new_config);
+}
+
 Status DB::close(DB* db) {
     if (db->sn) {
         _log_trace(db->p->myLog, "close snapshot %p", db);

--- a/src/log_reclaimer.cc
+++ b/src/log_reclaimer.cc
@@ -29,21 +29,25 @@ limitations under the License.
 
 namespace jungle {
 
-LogReclaimer::LogReclaimer(const std::string& _w_name,
-                          const GlobalConfig& _config)
+LogReclaimer::LogReclaimer(const std::string& wn,
+                          const GlobalConfig& g_config)
 {
-    workerName = _w_name;
-    gConfig = _config;
+    workerName = wn;
+    applyNewGlobalConfig(g_config);
+    handle = std::thread(&WorkerBase::loop, this);
+}
+
+void LogReclaimer::applyNewGlobalConfig(const GlobalConfig& g_config) {
+    gConfig = g_config;
     LogReclaimerOptions options;
-    options.sleepDuration_ms = gConfig.logFileReclaimerSleep_sec * 1000;
+    options.sleepDurationMs = gConfig.logFileReclaimerSleep_sec * 1000;
     options.worker = this;
     curOptions = options;
-    handle = std::thread(WorkerBase::loop, &curOptions);
 }
 
 LogReclaimer::~LogReclaimer() {}
 
-void LogReclaimer::work(WorkerOptions* opt_base) {
+void LogReclaimer::work() {
     Status s;
 
     DBMgr* dbm = DBMgr::getWithoutInit();

--- a/src/log_reclaimer.h
+++ b/src/log_reclaimer.h
@@ -27,14 +27,14 @@ public:
     struct LogReclaimerOptions : public WorkerOptions {
     };
 
-    LogReclaimer(const std::string& _w_name,
-                 const GlobalConfig& _config);
+    LogReclaimer(const std::string& wn,
+                 const GlobalConfig& c);
 
     ~LogReclaimer();
 
-    void work(WorkerOptions* opt_base);
+    void applyNewGlobalConfig(const GlobalConfig& g_config);
 
-    GlobalConfig gConfig;
+    void work();
 };
 
 

--- a/src/worker_mgr.cc
+++ b/src/worker_mgr.cc
@@ -36,16 +36,6 @@ void WorkerBase::updateGlobalConfig(const GlobalConfig& g_config) {
     newGConfig = std::make_unique<GlobalConfig>(g_config);
 }
 
-void WorkerBase::applyNewGlobalConfig(const GlobalConfig& g_config) {
-    gConfig = g_config;
-    WorkerOptions options;
-    options.sleepDurationMs = gConfig.flusherSleepDuration_ms;
-    options.worker = this;
-    curOptions = options;
-    _log_info(DBMgr::getWithoutInit()->getLogger(),
-              "worker %s applied new global config", workerName.c_str());
-}
-
 void WorkerBase::loop() {
     WorkerBase* worker = this;
 #ifdef __linux__

--- a/src/worker_mgr.cc
+++ b/src/worker_mgr.cc
@@ -31,10 +31,23 @@ WorkerBase::WorkerBase()
 WorkerBase::~WorkerBase() {
 }
 
-void WorkerBase::loop(WorkerOptions* opt) {
-    if (!opt || !opt->worker) return;
+void WorkerBase::updateGlobalConfig(const GlobalConfig& g_config) {
+    std::lock_guard<std::mutex> l(newGConfigLock);
+    newGConfig = std::make_unique<GlobalConfig>(g_config);
+}
 
-    WorkerBase* worker = opt->worker;
+void WorkerBase::applyNewGlobalConfig(const GlobalConfig& g_config) {
+    gConfig = g_config;
+    WorkerOptions options;
+    options.sleepDurationMs = gConfig.flusherSleepDuration_ms;
+    options.worker = this;
+    curOptions = options;
+    _log_info(DBMgr::getWithoutInit()->getLogger(),
+              "worker %s applied new global config", workerName.c_str());
+}
+
+void WorkerBase::loop() {
+    WorkerBase* worker = this;
 #ifdef __linux__
     std::string thread_name = "j_" + worker->workerName;
     thread_name = thread_name.substr(0, 15);
@@ -47,10 +60,20 @@ void WorkerBase::loop(WorkerOptions* opt) {
     _log_info(my_log, "worker %s initiated", worker->workerName.c_str());
 
     for (;;) {
+        {
+            std::lock_guard<std::mutex> l(worker->newGConfigLock);
+            if (worker->newGConfig) {
+                _log_info(my_log, "worker %s is applying new global config",
+                          worker->workerName.c_str());
+                worker->applyNewGlobalConfig(*worker->newGConfig);
+                worker->newGConfig.reset();
+            }
+        }
+
         // Sleep if IDLE or STOP.
         if ( (worker->status == IDLE || worker->status == STOP) &&
              !worker->doNotSleepNextTime.load() ) {
-            worker->ea.wait_ms(opt->sleepDuration_ms);
+            worker->ea.wait_ms(worker->curOptions.sleepDurationMs);
             worker->ea.reset();
         }
 
@@ -65,7 +88,7 @@ void WorkerBase::loop(WorkerOptions* opt) {
         WStatus val = WORKING;
         if (worker->status.compare_exchange_weak(exp, val)) {
             worker->doNotSleepNextTime = false;
-            worker->work(opt);
+            worker->work();
             // WORKING --> IDLE.
             exp = WORKING;
             val = IDLE;
@@ -166,6 +189,15 @@ WorkerBase* WorkerMgr::getWorker(const std::string& name) {
     }
 
     return nullptr;
+}
+
+Status WorkerMgr::updateGlobalConfig(const GlobalConfig& new_config) {
+    std::lock_guard<std::mutex> ll(workersLock);
+    for (auto& entry: workers) {
+        WorkerBase* worker = entry.second;
+        worker->updateGlobalConfig(new_config);
+    }
+    return Status();
 }
 
 } // namespace jungle


### PR DESCRIPTION
* It will update global config (such as sleep time and throttling limits) on-the-fly, without restarting the singleton instance.