### PR TITLE
Fix to min_seqnum mismatch between manifest and log file

### DIFF
--- a/src/log_manifest.cc
+++ b/src/log_manifest.cc
@@ -446,6 +446,15 @@ Status LogManifest::load(const std::string& path,
         }
         first_file_read = true;
 
+        if (l_file->getMinSeqNum() < min_seq) {
+            _log_warn(myLog, "min seq %s of log file %zu is less than "
+                      "manifest entry %s, will update manifest entry",
+                      _seq_str(l_file->getMinSeqNum()).c_str(),
+                      l_file_num,
+                      _seq_str(min_seq).c_str());
+            min_seq = l_file->getMinSeqNum();
+        }
+
         _log_info( myLog,
                    "log %ld, min seq %s, last flush %s, last sync %s",
                    l_file_num,

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -998,7 +998,7 @@ Status MemTable::load(RwSerializer& rws,
             uint64_t seq = 0;
             EB( loadRecord(rws, flags, seq),  "failed to load record" )
             last_seq = seq;
-            if (seq < min_seq_seen || min_seq_seen == 0) {
+            if (valid_number(seq) && (seq < min_seq_seen || min_seq_seen == 0)) {
                 min_seq_seen = seq;
             }
             num_record++;

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -981,6 +981,7 @@ Status MemTable::load(RwSerializer& rws,
     size_t last_valid_size = rws.pos();
     uint64_t num_record = 0, num_flush = 0, num_chk = 0;
     uint64_t last_seq = NOT_INITIALIZED;
+    uint64_t min_seq_seen = 0;
     std::string m;
 
     for (; rws.pos() < filesize;) {
@@ -997,6 +998,9 @@ Status MemTable::load(RwSerializer& rws,
             uint64_t seq = 0;
             EB( loadRecord(rws, flags, seq),  "failed to load record" )
             last_seq = seq;
+            if (seq < min_seq_seen || min_seq_seen == 0) {
+                min_seq_seen = seq;
+            }
             num_record++;
             last_valid_size = rws.pos();
 
@@ -1027,10 +1031,13 @@ Status MemTable::load(RwSerializer& rws,
         seqNumAlloc = last_seq;
         syncedSeqNum = last_seq;
     }
-    if (minSeqNum == NOT_INITIALIZED && NOT_INITIALIZED != last_seq) {
-        minSeqNum = 1;
-        _log_warn(myLog, "updated min_seq of log file %s to 1",
-                  logFile->filename.c_str());
+    if (valid_number(last_seq) && valid_number(min_seq_seen) &&
+        (minSeqNum == NOT_INITIALIZED || minSeqNum > min_seq_seen)) {
+        _log_warn(myLog, "updated min_seq of log file %s from %s to %s",
+                  logFile->filename.c_str(),
+                  _seq_str(minSeqNum).c_str(),
+                  _seq_str(min_seq_seen).c_str());
+        minSeqNum = min_seq_seen;
     }
 
     if (NOT_INITIALIZED != last_seq && last_seq < synced_seq) {
@@ -1531,8 +1538,8 @@ Status MemTable::getLogsToFlush(const uint64_t seq_num,
         Record* cur_rec = *entry;
         if (cur_rec->seqNum >= ii) {
             _log_err(myLog, "found duplicate seq number across different log files: "
-                     "%zu. will use newer one",
-                     cur_rec->seqNum);
+                     "seqnum %zu > %zu. will use newer one",
+                     cur_rec->seqNum, ii);
             list_out.pop_back();
             entry = list_out.rbegin();
         } else {

--- a/src/memtable.cc
+++ b/src/memtable.cc
@@ -1538,7 +1538,7 @@ Status MemTable::getLogsToFlush(const uint64_t seq_num,
         Record* cur_rec = *entry;
         if (cur_rec->seqNum >= ii) {
             _log_err(myLog, "found duplicate seq number across different log files: "
-                     "seqnum %zu > %zu. will use newer one",
+                     "seqnum %zu >= %zu. will use newer one",
                      cur_rec->seqNum, ii);
             list_out.pop_back();
             entry = list_out.rbegin();

--- a/tests/jungle/log_reclaim_test.cc
+++ b/tests/jungle/log_reclaim_test.cc
@@ -1884,7 +1884,7 @@ int sync_multiple_files_wo_manifest_test() {
     CHK_Z(jungle::DB::close(db));
 
     // Open clone.
-    // Even with crash without manifest sync, all 5 logs should be there.
+    // Even with crash without manifest sync, all 25 logs should be there.
     CHK_Z(jungle::DB::open(&db, clone_path, config));
 
     size_t exp_upto = 25;

--- a/tests/jungle/log_reclaim_test.cc
+++ b/tests/jungle/log_reclaim_test.cc
@@ -1793,6 +1793,116 @@ int sync_1st_file_wo_manifest_test(bool with_2nd_crash) {
     return 0;
 }
 
+int sync_1st_file_wo_manifest_and_then_graceful_shutdown_test() {
+    std::string filename;
+    TEST_SUITE_PREPARE_PATH(filename);
+
+    jungle::Status s;
+    jungle::DBConfig config;
+    TEST_CUSTOM_DB_CONFIG(config);
+    jungle::DB* db = nullptr;
+
+    jungle::GlobalConfig g_config;
+    g_config.numFlusherThreads = 1;
+    jungle::init(g_config);
+
+    config.maxEntriesInLogFile = 10;
+    config.skipManifestSync = true;
+    CHK_Z(jungle::DB::open(&db, filename, config));
+
+    // Do initial sync so that next sync will not write the manifest.
+    CHK_Z(db->sync(true));
+
+    // Write on the first log file and sync.
+    CHK_Z(insert_keys(db, 0, 5));
+    CHK_Z(db->sync(true));
+
+    // Copy file at this moment to mimic crash.
+    std::string clone_path = filename + "_clone";
+    TestSuite::copyfile(filename, clone_path);
+
+    CHK_Z(jungle::DB::close(db));
+
+    // Open clone.
+    // Even with crash without manifest sync, all 5 logs should be there.
+    CHK_Z(jungle::DB::open(&db, clone_path, config));
+
+    CHK_Z(db->sync(true));
+
+    // Graceful shutdown.
+    CHK_Z(jungle::DB::close(db));
+
+    // Reopen.
+    CHK_Z(jungle::DB::open(&db, clone_path, config));
+
+    // Insert one more key.
+    CHK_Z(insert_keys(db, 5, 6));
+
+    size_t exp_upto = 6;
+
+    // Before and after log flush, they should be visible.
+    CHK_Z(verify(db, exp_upto));
+    CHK_Z(db->sync(true));
+    CHK_Z(db->flushLogs());
+    CHK_Z(verify(db, exp_upto));
+    CHK_Z(jungle::DB::close(db));
+
+    CHK_Z(jungle::shutdown());
+
+    TEST_SUITE_CLEANUP_PATH();
+    return 0;
+}
+
+int sync_multiple_files_wo_manifest_test() {
+    std::string filename;
+    TEST_SUITE_PREPARE_PATH(filename);
+
+    jungle::Status s;
+    jungle::DBConfig config;
+    TEST_CUSTOM_DB_CONFIG(config);
+    jungle::DB* db = nullptr;
+
+    jungle::GlobalConfig g_config;
+    g_config.numFlusherThreads = 1;
+    jungle::init(g_config);
+
+    config.maxEntriesInLogFile = 10;
+    config.skipManifestSync = true;
+    CHK_Z(jungle::DB::open(&db, filename, config));
+
+    // Do initial sync so that next sync will not write the manifest.
+    CHK_Z(db->sync(true));
+
+    // Write on the multiple log files.
+    CHK_Z(insert_keys(db, 0, 25));
+    CHK_Z(db->sync(true));
+
+    // Copy file at this moment to mimic crash.
+    std::string clone_path = filename + "_clone";
+    TestSuite::copyfile(filename, clone_path);
+
+    CHK_Z(jungle::DB::close(db));
+
+    // Open clone.
+    // Even with crash without manifest sync, all 5 logs should be there.
+    CHK_Z(jungle::DB::open(&db, clone_path, config));
+
+    size_t exp_upto = 25;
+
+    // Before and after log flush, they should be visible.
+    CHK_Z(verify(db, exp_upto));
+    CHK_Z(db->sync(true));
+    CHK_Z(db->flushLogs());
+    CHK_Z(verify(db, exp_upto));
+    CHK_Z(jungle::DB::close(db));
+
+    CHK_Z(jungle::shutdown());
+
+    TEST_SUITE_CLEANUP_PATH();
+    return 0;
+}
+
+
 int empty_flush_race_test() {
     std::string filename;
     TEST_SUITE_PREPARE_PATH(filename);
@@ -2006,6 +2116,12 @@ int main(int argc, char** argv) {
     ts.doTest("sync 1st file without manifest test",
               sync_1st_file_wo_manifest_test,
               TestRange<bool>( {false, true} ));
+
+    ts.doTest("sync 1st file without manifest and then graceful shutdown test",
+              sync_1st_file_wo_manifest_and_then_graceful_shutdown_test);
+
+    ts.doTest("sync multiple files without manifest test",
+              sync_multiple_files_wo_manifest_test);
 
     ts.doTest("empty flush race test",
               empty_flush_race_test);


### PR DESCRIPTION
* When there is a mismatch between the minimum sequence number in the manifest and the actual minimum sequence number in the log file, update the manifest to reflect the actual value.

* Apply the same update to the memtable metadata as well.